### PR TITLE
fix: acc saber mini ranking when one of the categories contains no data

### DIFF
--- a/src/components/Ranking/AccSaberMini.svelte
+++ b/src/components/Ranking/AccSaberMini.svelte
@@ -35,16 +35,16 @@
 
         categories = await rankingService.getPlayer(playerId)
 
-        const currentCategory = categories.find(el => el.category == category)
+        const currentCategory = categories.find(el => el.category === category)
         
   
         isLoading = true;
   
-        const ranking = await rankingService.getMiniRanking(currentCategory.rank, category, numOfPlayers);
+        const ranking = await rankingService.getMiniRanking(currentCategory?.rank, category, numOfPlayers);
         if (!ranking) return;
         miniRanking = ranking
         categoriesOrder = categoriesOrder
-        compareAp = currentCategory.ap;
+        compareAp = currentCategory?.ap;
   
         dispatch('height-changed');
       } finally {
@@ -56,7 +56,7 @@
   </script>
   
   {#if miniRanking || isLoading}
-    <section transition:fade>
+    <section>
       <h3 style="display: flex;" class="title is-6">
         <div style="width: 20px; height: 20px" class="accsaber-icon"></div>
         <span>{capitalize(currentCategoryName)} accuracy ranking</span>
@@ -69,7 +69,7 @@
           {/each}
         </div>
       </h3>
-      {#if miniRanking}
+      {#if miniRanking?.length}
         <div class="players">
           {#each miniRanking as player}
             <div class="rank">
@@ -83,6 +83,8 @@
             </div>
           {/each}
         </div>
+      {:else}
+        No data.
       {/if}
     </section>
   {/if}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1758707/180452976-a11746fa-c96a-4e27-83e8-d0c0336468c4.png)

After: 
![image](https://user-images.githubusercontent.com/1758707/180453016-8a92dea7-b972-4e4e-a20a-4e3eda55d102.png)
