### PR TITLE
fix: hide map search tool by default

### DIFF
--- a/src/pages/RtDashboard.svelte
+++ b/src/pages/RtDashboard.svelte
@@ -59,7 +59,7 @@
 	let logTypeFilter = [];
 	let logPlayerFilter = '';
 
-	let showMapSearch = true;
+	let showMapSearch = false;
 	let mapIsSearched = false;
 	let mapSearchError = null;
 	let mapHash = '';


### PR DESCRIPTION
I set this to make it easier to develop and forgot to remove it before PR.