### PR TITLE
Adding line breaks to PP/Acc hover overs + adding hover to Nominated scores with mistakes

### DIFF
--- a/src/components/Common/Accuracy.svelte
+++ b/src/components/Common/Accuracy.svelte
@@ -36,7 +36,7 @@
 	$: badge = getBadge(score?.acc);
 	$: fcacc =
 		score.fcAccuracy && score.acc && Math.abs(score.fcAccuracy * 100 - score.acc) > 0.01
-			? ' FC acc: ' + formatNumber(score.fcAccuracy * 100) + '%'
+			? '\nFC acc: ' + formatNumber(score.fcAccuracy * 100) + '%'
 			: '';
 	$: mods = score?.mods;
 

--- a/src/components/Score/Pp.svelte
+++ b/src/components/Score/Pp.svelte
@@ -81,16 +81,16 @@
 
 		prevTitle =
 			weighted || improvements
-				? `${weighted ? `Weighted: ${formatNumber(weighted)}${suffix}, ` : ''}${
-						improvements?.pp ? `PP improvement: ${formatNumber(improvements.pp, 2, true)}${suffix}, ` : ''
-				  }${improvements?.totalPp ? `Total PP gain: ${formatNumber(improvements.totalPp, 2, true)}${suffix}` : ''}`
+				? `${weighted ? `Weighted: ${formatNumber(weighted)}${suffix}\n` : ''}${
+						improvements?.pp ? `PP improvement: ${formatNumber(improvements.pp, 2, true)}${suffix}\n` : ''
+				  }${improvements?.totalPp ? `Total PP gain: ${formatNumber(improvements.totalPp, 2, true)}${suffix}\n` : ''}`
 				: null;
 
 		if (bonusPp) {
-			prevTitle += ' PP bonus: ' + formatNumber(bonusPp) + suffix;
+			prevTitle += `PP bonus: ${formatNumber(bonusPp)}${suffix}\n`;
 		}
 		if (fcPp) {
-			prevTitle += ', Full combo PP: ' + formatNumber(fcPp) + suffix;
+			prevTitle += `Full combo PP: ${formatNumber(fcPp)}${suffix}\n`;
 		}
 	}
 

--- a/src/utils/beatleader/pp.js
+++ b/src/utils/beatleader/pp.js
@@ -1,4 +1,45 @@
+import {formatNumber} from '../../utils/format';
+
+
 export const WEIGHT_COEFFICIENT = 0.965;
+
 
 export const getTotalPpFromSortedPps = (ppArray, startIdx = 0) =>
 	ppArray.reduce((cum, pp, idx) => cum + Math.pow(WEIGHT_COEFFICIENT, idx + startIdx) * pp, 0);
+
+
+export const getFCPPTitle = (fcPp, suffix) => {
+	if (!fcPp | fcPp <= 0) {
+		return '';
+	}
+	return `Full combo PP: ${formatNumber(fcPp)}${suffix}`;
+}
+
+
+export const buildCurve = (acc, stars) => {
+	var l = 1 - (0.03 * (stars - 3.0)) / 11.0;
+	var a = 0.96 * l;
+	var f = 1.2 - (0.6 * stars) / 14.0;
+	return Math.pow(Math.log10(l / (l - acc)) / Math.log10(l / (l - a)), f);
+}
+
+
+export const getPPFromAcc = (acc, stars) => {
+	return buildCurve(acc, stars - 0.5) * (stars + 0.5) * 42;
+}
+
+
+export const computeModifierStars = (stars, mods) => {
+
+	// Make sure we have a valid modifiers array
+	if (!mods || !Array.isArray(mods) || mods.length === 0) {
+		return stars;
+	}
+
+	const positiveModifiersSum = mods?.reduce((sum, mod) => sum + (mod.value > 0 ? mod.value : 0), 0) ?? 0;
+	const negativeModifiersSum = mods?.reduce((sum, mod) => sum + (mod.value < 0 ? mod.value : 0), 0) ?? 0;
+	const modifiedStars = stars * (1 + positiveModifiersSum + negativeModifiersSum);
+
+	return modifiedStars;
+
+}


### PR DESCRIPTION
I've added some line breaks to make the hover a bit easier to read:

![image](https://user-images.githubusercontent.com/84289648/205474922-4607d665-abbf-4065-83a2-138173dc8be5.png)


I've also added the same functionality to nominated scores with mistakes.

![image](https://user-images.githubusercontent.com/84289648/205474912-57cda537-c8b5-46a3-9569-b5d5831274fd.png)

I also extracted some logic out of PPCurve.svelte that needed to be used in places where fcPp wasn't available but fcAccuracy was.