### PR TITLE
Esc key now cancels profile editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 node_modules
 public/build
 build-info.js
+.yarn
+.yarnrc.yml
 # Local Netlify folder
 .netlify

--- a/src/components/Player/Profile.svelte
+++ b/src/components/Player/Profile.svelte
@@ -144,7 +144,13 @@
 			if (editModel) editModel.isSaving = false;
 		}
 	}
-
+	function onKeyUp(event){
+		switch (event.key){
+			case "Escape": 
+				onCancelEditModel();
+			
+		}		
+	}
 	let modalShown;
 
 	$: playerId = playerData && playerData.playerId ? playerData.playerId : null;
@@ -220,7 +226,7 @@
 	$: pinnedScoresStore.fetchScores(playerData?.playerId);
 	$: statsHistoryStore.fetchStats(playerData, $configStore.preferences.daysOfHistory);
 </script>
-
+<svelte:window on:keyup={onKeyUp}/>
 {#if playerInfo?.clans?.filter(cl => cl.tag == 'BB').length}
 	<Rain />
 {/if}


### PR DESCRIPTION
Added an onkeyup listener in the "Profile" component, which, when the escape key is pressed during profile editing, it is cancelled. This functions the same as clicking the "Cancel" button, but attributes an intuitive keybind to it.