### PR TITLE
Screenshots now save when copying to clipboard is impossible

### DIFF
--- a/src/components/Player/Profile.svelte
+++ b/src/components/Player/Profile.svelte
@@ -144,29 +144,37 @@
 			if (editModel) editModel.isSaving = false;
 		}
 	}
+	function successToast(text) {
+		addNotification({
+			text: text,
+			position: 'top-right',
+			type: 'success',
+			removeAfter: 2000,
+		});
+	}
 	async function takeScreenshot() {
-		let isFirefox = false;
-		if (navigator.userAgent.indexOf('Firefox') != -1) {
-			isFirefox = true;
-		}
 		try {
 			const element = document.querySelector('.content-box');
 			const canvas = await html2canvas(element, {useCORS: true, backgroundColor: '#252525'});
 			const blob = await new Promise(resolve => canvas.toBlob(resolve));
-			await navigator.clipboard.write([new ClipboardItem({'image/png': blob})]);
-
+			try {
+				await navigator.clipboard.write([new ClipboardItem({'image/png': blob})]);
+				successToast('Screenshot Copied to Clipboard');
+			} catch {
+				const anchor = document.createElement('a');
+				const objURL = URL.createObjectURL(blob);
+				anchor.href = objURL;
+				anchor.style.display = 'none';
+				anchor.download = name + '.png';
+				document.body.appendChild(anchor);
+				anchor.click();
+				document.body.removeChild(anchor);
+				URL.revokeObjectURL(objURL);
+				successToast('Screenshot Saved');
+			}
+		} catch (e) {
 			addNotification({
-				text: 'Screenshot Copied to Clipboard',
-				position: 'top-right',
-				type: 'success',
-				removeAfter: 2000,
-			});
-		} catch {
-			const errorText =
-				'Screenshot Failed: ' +
-				(isFirefox ? 'The issue could be that, on firefox, the "clipboardItem" permission is disabled by default.' : 'You likely do not have the correct permissions');
-			addNotification({
-				text: errorText,
+				text: 'Screenshot Failed',
 				position: 'top-right',
 				type: 'error',
 				removeAfter: 4000,
@@ -289,7 +297,6 @@
 					</div>
 				{/if}
 			</div>
-
 			{#if roles}
 				<div class="role-icons">
 					{#each roles as role, idx}

--- a/src/components/Player/Profile.svelte
+++ b/src/components/Player/Profile.svelte
@@ -145,10 +145,16 @@
 		}
 	}
 	async function takeScreenshot() {
+		let isFirefox = false;
+		if (navigator.userAgent.indexOf('Firefox') != -1) {
+			isFirefox = true;
+		}
 		try {
-			let element = document.querySelector('.content-box');
-			let canvas = await html2canvas(element, {useCORS: true, backgroundColor: '#252525'});
-			canvas.toBlob(blob => navigator.clipboard.write([new ClipboardItem({'image/png': blob})]));
+			const element = document.querySelector('.content-box');
+			const canvas = await html2canvas(element, {useCORS: true, backgroundColor: '#252525'});
+			const blob = await new Promise(resolve => canvas.toBlob(resolve));
+			await navigator.clipboard.write([new ClipboardItem({'image/png': blob})]);
+
 			addNotification({
 				text: 'Screenshot Copied to Clipboard',
 				position: 'top-right',
@@ -156,11 +162,14 @@
 				removeAfter: 2000,
 			});
 		} catch {
+			const errorText =
+				'Screenshot Failed: ' +
+				(isFirefox ? 'On firefox, the "clipboardItem" permission is disabled by default' : 'You do not have the correct permissions');
 			addNotification({
-				text: 'Screenshot Failed',
+				text: errorText,
 				position: 'top-right',
 				type: 'error',
-				removeAfter: 2000,
+				removeAfter: 4000,
 			});
 		}
 	}

--- a/src/components/Player/Profile.svelte
+++ b/src/components/Player/Profile.svelte
@@ -164,7 +164,7 @@
 		} catch {
 			const errorText =
 				'Screenshot Failed: ' +
-				(isFirefox ? 'On firefox, the "clipboardItem" permission is disabled by default' : 'You do not have the correct permissions');
+				(isFirefox ? 'The issue could be that, on firefox, the "clipboardItem" permission is disabled by default.' : 'You likely do not have the correct permissions');
 			addNotification({
 				text: errorText,
 				position: 'top-right',


### PR DESCRIPTION
If the screenshot cannot be copied to clipboard, the site attempts to save it as a file with the user's username as it's filename.