### PR TITLE
Fix spelling of "anonymous"

### DIFF
--- a/src/components/Player/utils/profile.js
+++ b/src/components/Player/utils/profile.js
@@ -68,7 +68,7 @@ function updateScoresStats(playerData) {
 
 			if (s.key == 'authorizedReplayWatched') {
 				value = scoreStats['authorizedReplayWatched'] + scoreStats['anonimusReplayWatched'];
-				s.title = `Authorized players watched: ${scoreStats['authorizedReplayWatched']}, anonimus players watched: ${scoreStats['anonimusReplayWatched']}`;
+				s.title = `Authorized players watched: ${scoreStats['authorizedReplayWatched']}, anonymous players watched: ${scoreStats['anonimusReplayWatched']}`;
 			}
 
 			let resultValue = value;


### PR DESCRIPTION
"Anonymous" is misspelled as "anonimus" in the mouseover text of the replays watched stat on user profiles:

![Example screenshot](https://i.imgur.com/9e7bNa8.png)

This PR corrects the user-facing text, but internally the stat is still called `anonimusReplayWatched` so that nothing should break.