### PR TITLE
Updated css of the map hash elements to remove the trailing space when double clicking

### DIFF
--- a/src/components/Leaderboard/LeaderboardHeader.svelte
+++ b/src/components/Leaderboard/LeaderboardHeader.svelte
@@ -99,7 +99,7 @@
 				{/if}
 				{#if $configStore?.leaderboardPreferences?.showHashInHeader}
 					<div>
-						<small class="level-author">{song.hash.toUpperCase()}</small>
+						<small class="level-author" style="display: inline-block;">{song.hash.toUpperCase()}</small>
 						{#if latestHash}
 							<i class="fa fa-check" style="color: lime;" title="Latest map version" />
 						{:else if latestHash == undefined}

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -1009,7 +1009,7 @@
 									<PredictedAccGraph {leaderboard} />
 									{#if !$configStore?.leaderboardPreferences?.showHashInHeader}
 										<div>
-											<small class="level-author">{song.hash.toUpperCase()}</small>
+											<small style="display: inline-block;">{song.hash.toUpperCase()}</small>
 											{#if latestHash}
 												<i class="fa fa-check" style="color: lime;" title="Latest map version" />
 											{:else if latestHash == undefined}


### PR DESCRIPTION
Currently double clicking the hash element results in the selection including a trailing space like this 
![image](https://github.com/BeatLeader/beatleader-website/assets/55551604/2d630e9c-e688-4975-8e7d-6402a431ee60)

Double clicking with the change in this PR
![image](https://github.com/BeatLeader/beatleader-website/assets/55551604/370c1530-7ffc-443a-be22-6f390fba8bee)
