### PR TITLE
Migrate to Svelte 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,25 +26,25 @@
     "luxon": "^2.0.2",
     "p-queue": "=7.3.0",
     "prettier": "^2.8.1",
-    "prettier-plugin-svelte": "^2.7.0",
+    "prettier-plugin-svelte": "^2.10.1",
     "rollup": "^2.3.4",
     "rollup-plugin-css-only": "^3.1.0",
     "rollup-plugin-less": "https://github.com/NSGolova/rollup-plugin-less.git",
     "rollup-plugin-livereload": "^2.0.0",
     "rollup-plugin-replace": "^2.2.0",
-    "rollup-plugin-svelte": "^7.0.0",
+    "rollup-plugin-svelte": "^7.1.5",
     "rollup-plugin-svg": "^2.0.0",
     "rollup-plugin-terser": "^7.0.0",
-    "svelte": "^3.0.0",
-    "svelte-check": "^1.0.0",
+    "svelte": "^4.0.0",
+    "svelte-check": "^3.4.3",
     "svelte-dnd-action": "^0.9.26",
-    "svelte-meta-tags": "^2.6.4",
+    "svelte-meta-tags": "3.0.3",
     "svelte-notifications": "^0.9.97",
-    "svelte-preprocess": "^4.0.0",
+    "svelte-preprocess": "^5.0.3",
     "svelte-range-slider-pips": "^2.0.3",
-    "svelte-routing": "^1.6.0",
+    "svelte-routing": "2.1.0",
     "tslib": "^2.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^5.0.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
@@ -56,6 +56,6 @@
     "svelte-chartjs": "^3.1.2",
     "svelte-confetti": "^1.2.2",
     "svelte-select": "^4.4.7",
-    "svelte-simple-modal": "^1.1.1"
+    "svelte-simple-modal": "1.6.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -92,6 +92,7 @@ export default [
 			resolve({
 				browser: true,
 				dedupe: ['svelte'],
+				exportConditions: ['browser'],
 			}),
 			commonjs(),
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -122,11 +122,11 @@
 							<LandingPage />
 						{/if}
 					</Route>
-					<Route path="/u/:initialPlayerId/*initialParams" let:params let:location>
-						<PlayerPage initialPlayerId={params.initialPlayerId} initialParams={params.initialParams} {location} />
+					<Route path="/u/:initialPlayerId/*initialParams" let:params>
+						<PlayerPage initialPlayerId={params.initialPlayerId} initialParams={params.initialParams} />
 					</Route>
-					<Route path="/staff" let:location>
-						<StaffDashboard {location} />
+					<Route path="/staff">
+						<StaffDashboard />
 					</Route>
 					<Route path="/privacy" component={PrivacyPage} />
 					<Route path="/about" component={AboutPage} />
@@ -139,44 +139,42 @@
 						<PatreonPage action="linkPatreon" />
 					</Route>
 					<Route path="/supporting-project" component={PatreonPage} />
-					<Route path="/ranking/*page" let:params let:location>
-						<RankingPage page={params.page} {location} />
+					<Route path="/ranking/*page" let:params>
+						<RankingPage page={params.page} />
 					</Route>
-					<Route path="/leaderboard/:type/:leaderboardId/*page" let:params let:location>
+					<Route path="/leaderboard/:type/:leaderboardId/*page" let:params>
 						<LeaderboardPage
 							leaderboardId={params.leaderboardId}
 							type={params.type}
 							page={params.page}
-							{location}
 							dontChangeType={false}
 							showCurve={true}
 							separatePage={true} />
 					</Route>
-					<Route path="/leaderboard/approval/:type/:leaderboardId/*page" let:params let:location>
+					<Route path="/leaderboard/approval/:type/:leaderboardId/*page" let:params>
 						<LeaderboardPage
 							leaderboardId={params.leaderboardId}
 							type={params.type}
 							page={params.page}
-							{location}
 							dontChangeType={false}
 							showCurve={true}
 							separatePage={true}
 							showApproveRequest={true} />
 					</Route>
-					<Route path="/leaderboards/*page" let:params let:location>
-						<LeaderboardsPage page={params.page} {location} />
+					<Route path="/leaderboards/*page" let:params>
+						<LeaderboardsPage page={params.page} />
 					</Route>
 					<Route path="/clan/:clanId/*page" let:params>
 						<ClanPage clanId={params.clanId} page={params.page} />
 					</Route>
-					<Route path="/event/:eventId/*page" let:params let:location>
-						<EventPage eventId={params.eventId} page={params.page} {location} />
+					<Route path="/event/:eventId/*page" let:params>
+						<EventPage eventId={params.eventId} page={params.page} />
 					</Route>
-					<Route path="/events/*page" let:params let:location>
-						<EventsPage page={params.page} {location} />
+					<Route path="/events/*page" let:params>
+						<EventsPage page={params.page} />
 					</Route>
-					<Route path="/clans/*page" let:params let:location>
-						<ClansPage page={params.page} {location} />
+					<Route path="/clans/*page" let:params>
+						<ClansPage page={params.page} />
 					</Route>
 					<Route path="/playlists/*id" let:params>
 						<PlaylistsPage index={params.id} />
@@ -190,8 +188,8 @@
 					<Route path="/signin/*action" let:params>
 						<SigninPage action={params.action} />
 					</Route>
-					<Route path="/signin/oauth2" let:location>
-						<OauthSignInPage {location} />
+					<Route path="/signin/oauth2">
+						<OauthSignInPage />
 					</Route>
 					<Route path="/*" component={NotFoundPage} />
 				</div>

--- a/src/components/BeatSavior/Details.svelte
+++ b/src/components/BeatSavior/Details.svelte
@@ -37,7 +37,7 @@
 </script>
 
 {#if beatSavior}
-	<section class="beat-savior" transition:fade>
+	<section class="beat-savior" transition:fade|global>
 		{#if $configStore?.scoreDetailsPreferences?.showScoreMetrics || $configStore?.scoreDetailsPreferences?.showHandsAcc || (showGrid && $configStore?.scoreDetailsPreferences?.showSliceDetails)}
 			<DetailsBox cls="details-and-hands">
 				{#if $configStore?.scoreDetailsPreferences?.showScoreMetrics}

--- a/src/components/Clans/ClanInfo.svelte
+++ b/src/components/Clans/ClanInfo.svelte
@@ -231,7 +231,7 @@
 </script>
 
 {#if enableCreateMode || clan?.id}
-	<section class="clan-info" transition:fade>
+	<section class="clan-info" transition:fade|global>
 		<div class="clanData">
 			<div
 				class="imageInput"

--- a/src/components/Clans/ClanInfoSmall.svelte
+++ b/src/components/Clans/ClanInfoSmall.svelte
@@ -40,7 +40,7 @@
 </script>
 
 {#if clan?.id}
-	<section class="clan-info {tag == 'GAY' ? 'rainbow' : ''}" transition:fade>
+	<section class="clan-info {tag == 'GAY' ? 'rainbow' : ''}" transition:fade|global>
 		<div class="clanData">
 			<div class="imageInput">
 				<img class="clanImage" src={iconUrl} alt="ClanIcon" />

--- a/src/components/Common/Achievements/AchievementCompact.svelte
+++ b/src/components/Common/Achievements/AchievementCompact.svelte
@@ -30,7 +30,7 @@
 </div>
 
 <Popover triggerEvents={['hover', 'focus']} {referenceElement} placement="top" spaceAway={10}>
-	<div class="popover-contents" transition:fade={{duration: 250}}>
+	<div class="popover-contents" transition:fade|global={{duration: 250}}>
 		<AchievementDetails {achievement} />
 	</div>
 </Popover>

--- a/src/components/Common/Modal.svelte
+++ b/src/components/Common/Modal.svelte
@@ -53,7 +53,7 @@
 	on:click={() => {
 		closeable ? close() : null;
 	}}
-	transition:fade />
+	transition:fade|global />
 
 <div
 	class="ss-modal"
@@ -61,7 +61,7 @@
 	aria-modal="true"
 	bind:this={modal}
 	style="--width: {width}; --height: {height};"
-	transition:fly={{y: heightInPx ? heightInPx : 300}}>
+	transition:fly|global={{y: heightInPx ? heightInPx : 300}}>
 	<div class="inner">
 		<slot />
 	</div>

--- a/src/components/Common/PlayerNameWithFlag.svelte
+++ b/src/components/Common/PlayerNameWithFlag.svelte
@@ -37,7 +37,7 @@
 
 {#if !disablePopover && player && player.playerInfo}
 	<Popover triggerEvents={['hover', 'focus']} {referenceElement} placement="top" spaceAway={10}>
-		<div class="popover-contents" transition:fade={{duration: 250}}>
+		<div class="popover-contents" transition:fade|global={{duration: 250}}>
 			<MiniProfile {player} />
 		</div>
 	</Popover>

--- a/src/components/Leaderboard/ExmachinaCurve.svelte
+++ b/src/components/Leaderboard/ExmachinaCurve.svelte
@@ -159,7 +159,7 @@
 	$: loading = false;
 </script>
 
-<article transition:fade>
+<article transition:fade|global>
 	<span>Predicted accability:</span>
 	<section class="accuracy-chart" style="--height: {height}">
 		<canvas class="chartjs" bind:this={canvas} />

--- a/src/components/Leaderboard/LeaderboardHeader.svelte
+++ b/src/components/Leaderboard/LeaderboardHeader.svelte
@@ -61,7 +61,7 @@
 		style={coverUrl
 			? `background: linear-gradient(#303030a2, #303030a2), url(${coverUrl}); background-repeat: no-repeat; background-size: cover; background-position: center;`
 			: ''}
-		transition:fade>
+		transition:fade|global>
 		<div class="cinematics">
 			<div class="cinematics-canvas">
 				<canvas bind:this={cinematicsCanvas} style="position: absolute; width: 100%; height: 100%; opacity: 0" />

--- a/src/components/Leaderboard/LeaderboardMeta.svelte
+++ b/src/components/Leaderboard/LeaderboardMeta.svelte
@@ -28,7 +28,7 @@
 		title,
 		description,
 		images: [{url: image}],
-		site_name: ssrConfig.name,
+		siteName: ssrConfig.name,
 	}}
 	twitter={{
 		handle: '@handle',

--- a/src/components/Leaderboard/PredictedAccGraph.svelte
+++ b/src/components/Leaderboard/PredictedAccGraph.svelte
@@ -14,7 +14,7 @@
 	$: !exmachinadata && starGeneratorStore.fetchExMachina(hash, diffInfo?.diff, diffInfo?.type);
 </script>
 
-<article transition:fade>
+<article transition:fade|global>
 	{#if notes}
 		<ExmachinaCurve {notes} on:speed-changed={e => starGeneratorStore.fetchExMachina(hash, diffInfo?.diff, diffInfo?.type, e.detail)} />
 	{/if}

--- a/src/components/Leaderboard/QualificationApproval.svelte
+++ b/src/components/Leaderboard/QualificationApproval.svelte
@@ -27,7 +27,7 @@
 	$: currentMapperId = $account.player ? $account.player.playerInfo.mapperId : null;
 </script>
 
-<div transition:fade>
+<div transition:fade|global>
 	{#if !approved}
 		<div class="title-box">
 			Hello {leaderboard?.song.levelAuthorName}, your map made such an impression on our community that we wanted to rank it!🎉<br />
@@ -55,7 +55,7 @@
 		</div>
 
 		{#if showDetails}
-			<div transition:slide class="tab title-box">
+			<div transition:slide|global class="tab title-box">
 				Ranking means players will be receiving PP from your map. And probably putting a lot of effort in improving on it.<br />
 				After your map is ranked - please don't remove or update it on the BeatSaver.<br />
 				Doing so will make the ranked leaderboard impossible to score on for new players which will bar you from ranking future maps<br />

--- a/src/components/Leaderboard/QualityVotes/QualityVoting.svelte
+++ b/src/components/Leaderboard/QualityVotes/QualityVoting.svelte
@@ -124,7 +124,7 @@
 {#if positiveVotes?.length}
 	<Popover triggerEvents={['hover', 'focus']} referenceElement={positiveCounter} placement="top" spaceAway={10}>
 		<ContentBox>
-			<div class="popover-contents" transition:fade={{duration: 250}}>
+			<div class="popover-contents" transition:fade|global={{duration: 250}}>
 				{#each positiveVotes as vote}
 					<QualityVote {vote} />
 				{/each}
@@ -136,7 +136,7 @@
 {#if neutralVotes?.length}
 	<Popover triggerEvents={['hover', 'focus']} referenceElement={neutralCounter} placement="top" spaceAway={10}>
 		<ContentBox>
-			<div class="popover-contents" transition:fade={{duration: 250}}>
+			<div class="popover-contents" transition:fade|global={{duration: 250}}>
 				{#each neutralVotes as vote}
 					<QualityVote {vote} />
 				{/each}
@@ -148,7 +148,7 @@
 {#if negativeVotes?.length}
 	<Popover triggerEvents={['hover', 'focus']} referenceElement={negativeCounter} placement="top" spaceAway={10}>
 		<ContentBox>
-			<div class="popover-contents" transition:fade={{duration: 250}}>
+			<div class="popover-contents" transition:fade|global={{duration: 250}}>
 				{#each negativeVotes as vote}
 					<QualityVote {vote} />
 				{/each}

--- a/src/components/Leaderboard/RankedApproval.svelte
+++ b/src/components/Leaderboard/RankedApproval.svelte
@@ -26,7 +26,7 @@
 	}
 </script>
 
-<div transition:fade>
+<div transition:fade|global>
 	{#if !ranked}
 		<div class="title-box">
 			Map is ready to be ranked🎉<br />

--- a/src/components/Leaderboards/MapCardContent.svelte
+++ b/src/components/Leaderboards/MapCardContent.svelte
@@ -40,7 +40,7 @@
 	$: coverImage && retrieveBackgroundColor(coverImage);
 </script>
 
-<div class={`map-card row-${idx} ${viewType}`} in:fly={{delay: 250 + idx * 50, duration: 400, y: 100}} out:fade={{delay: 0, duration: 150}}>
+<div class={`map-card row-${idx} ${viewType}`} in:fly|global={{delay: 250 + idx * 50, duration: 400, y: 100}} out:fade|global={{delay: 0, duration: 150}}>
 	<div class="card-background" style="background-image:  url({coverImage});" data-atropos-offset="-1" />
 	<div class="map-card-header">
 		<div class="difficulty">

--- a/src/components/Player/BlBadges.svelte
+++ b/src/components/Player/BlBadges.svelte
@@ -5,7 +5,7 @@
 </script>
 
 {#if badges}
-	<div class="bl-badges" transition:fade={{duration: 500}}>
+	<div class="bl-badges" transition:fade|global={{duration: 500}}>
 		{#each badges as badge (badge.src)}
 			{#if badge.link}
 				<a href={badge.link}>

--- a/src/components/Player/FailedScore.svelte
+++ b/src/components/Player/FailedScore.svelte
@@ -40,8 +40,8 @@
 {#if songScore}
 	<div
 		class={`song-score row-${idx}`}
-		in:fly={{x: 300, delay: idx * 30, duration: 500}}
-		out:fade={{duration: 100}}
+		in:fly|global={{x: 300, delay: idx * 30, duration: 500}}
+		out:fade|global={{duration: 100}}
 		class:with-details={showDetails}>
 		<div class="icons up-to-tablet">
 			<Icons {hash} {twitchUrl} {diffInfo} replayLink={score.replay} altReplay={true} />
@@ -128,7 +128,7 @@
 		</div>
 
 		{#if showDetails}
-			<div transition:slide>
+			<div transition:slide|global>
 				<SongScoreDetails
 					{playerId}
 					{songScore}

--- a/src/components/Player/PlayerMeta.svelte
+++ b/src/components/Player/PlayerMeta.svelte
@@ -34,7 +34,7 @@
 		title: $playerStore?.name,
 		description,
 		images: [{url: $playerStore?.playerInfo.avatar}],
-		site_name: ssrConfig.name,
+		siteName: ssrConfig.name,
 	}}
 	twitter={{
 		handle: '@handle',

--- a/src/components/Player/ProfileCards/AccSaberSwipeCard.svelte
+++ b/src/components/Player/ProfileCards/AccSaberSwipeCard.svelte
@@ -72,7 +72,7 @@
 </script>
 
 {#if playerInfoByCategory}
-	<div class="accsaber-swipe-card" transition:fade>
+	<div class="accsaber-swipe-card" transition:fade|global>
 		<h3 class="title is-6">
 			<a href={`https://accsaber.com/player-profile/${playerInfoByCategory?.[0]?.playerInfo?.playerId}`} target="_blank" rel="noreferrer">
 				<img src="/assets/accsaber-logo.png" alt="AccSaberLogo" /> <span>AccSaber</span>

--- a/src/components/Player/ProfileCards/BeatSaviorSwipeCard.svelte
+++ b/src/components/Player/ProfileCards/BeatSaviorSwipeCard.svelte
@@ -181,7 +181,7 @@
 	$: stats = calculateStats(filteredScores);
 </script>
 
-<div class="beat-savior" transition:fade>
+<div class="beat-savior" transition:fade|global>
 	<h3 class="title is-6">
 		<a href={`https://beat-savior.herokuapp.com/BeatSaviorSwipeCard.svelte#/profile/${playerId}`} target="_blank" rel="noreferrer">
 			<span class="beatsavior-icon" />

--- a/src/components/Player/SongScore.svelte
+++ b/src/components/Player/SongScore.svelte
@@ -113,8 +113,8 @@
 {#if songScore}
 	<div
 		class={`song-score row-${idx} ${inList ? 'score-in-list' : ''}`}
-		in:maybe={{fn: fly, x: animationSign * 300, delay: idx * 30, duration: 300}}
-		out:maybe={{fn: fade, duration: 100}}
+		in:maybe|global={{fn: fly, x: animationSign * 300, delay: idx * 30, duration: 300}}
+		out:maybe|global={{fn: fade, duration: 100}}
 		class:with-details={showDetails}>
 		<div class="main" class:beat-savior={service === 'beatsavior'} class:accsaber={service === 'accsaber'}>
 			<span class="rank tablet-and-up">
@@ -239,7 +239,7 @@
 		</div>
 
 		{#if showDetails}
-			<div transition:slide>
+			<div transition:slide|global>
 				<SongScoreDetails
 					{playerId}
 					{songScore}

--- a/src/components/Player/TwitchVideos.svelte
+++ b/src/components/Player/TwitchVideos.svelte
@@ -7,7 +7,7 @@
 </script>
 
 {#if videos && videos.length}
-	<section transition:fade>
+	<section transition:fade|global>
 		<h3 class="title is-6"><i class="fab fa-twitch" /> Twitch VODs</h3>
 
 		<div class="videos">

--- a/src/components/Playlists/Playlist.svelte
+++ b/src/components/Playlists/Playlist.svelte
@@ -147,8 +147,8 @@
 {#if playlist}
 	<div
 		class={`song-score row-${idx}`}
-		in:fly={{x: 300, delay: idx * 30, duration: 500}}
-		out:fade={{duration: 100}}
+		in:fly|global={{x: 300, delay: idx * 30, duration: 500}}
+		out:fade|global={{duration: 100}}
 		class:with-details={detailsOpened}>
 		<div class="playlistInfo" on:click={() => onDetailsButtonClick()}>
 			<td class="col--details-btn">

--- a/src/components/Playlists/Playlist.svelte
+++ b/src/components/Playlists/Playlist.svelte
@@ -270,7 +270,7 @@
 						url: BL_API_URL + 'playlist/image/' + playlistId + '.png',
 					},
 				],
-				site_name: ssrConfig.name,
+				siteName: ssrConfig.name,
 			}}
 			twitter={{
 				handle: '@handle',

--- a/src/components/Playlists/Song.svelte
+++ b/src/components/Playlists/Song.svelte
@@ -70,7 +70,7 @@
 	$: updateSongKey(hash);
 </script>
 
-<div class="container row-${idx}" transition:slide>
+<div class="container row-${idx}" transition:slide|global>
 	{#if songInfo}
 		<img class="cover" src={coverUrl} alt="" />
 		<div style="display: grid; padding-left: 1em">

--- a/src/components/Ranking/Mini.svelte
+++ b/src/components/Ranking/Mini.svelte
@@ -41,7 +41,7 @@
 </script>
 
 {#if miniRanking && miniRanking[0]}
-	<section transition:fade>
+	<section transition:fade|global>
 		<h3 class="title is-6">
 			{#if country}
 				<Flag country={miniRanking[0].country} />

--- a/src/components/Ranking/PlayerCard.svelte
+++ b/src/components/Ranking/PlayerCard.svelte
@@ -143,7 +143,7 @@
 
 {#if player && player.playerInfo}
 	<Popover triggerEvents={['hover', 'focus']} {referenceElement} placement="top" spaceAway={10}>
-		<div class="popover-contents" transition:fade={{duration: 250}}>
+		<div class="popover-contents" transition:fade|global={{duration: 250}}>
 			<MiniProfile {player} />
 		</div>
 	</Popover>

--- a/src/components/Ranking/RankingMeta.svelte
+++ b/src/components/Ranking/RankingMeta.svelte
@@ -53,7 +53,7 @@
 		title,
 		description,
 		images: [{url: CURRENT_URL + '/assets/logo-small.png'}],
-		site_name: ssrConfig.name,
+		siteName: ssrConfig.name,
 	}}
 	twitter={{
 		handle: '@handle',

--- a/src/components/Ranking/RankingTable.svelte
+++ b/src/components/Ranking/RankingTable.svelte
@@ -388,7 +388,7 @@
 		{#each $rankingStore.data as player, idx (player?.playerId)}
 			<div
 				class="ranking-grid-row {!noIcons && $configStore.preferences.showFriendsButtonOnRanking ? 'with-friends-button' : ''}"
-				in:fly={{delay: idx * 10, x: 100}}>
+				in:fly|global={{delay: idx * 10, x: 100}}>
 				<PlayerCard
 					{player}
 					playerId={mainPlayerId}

--- a/src/components/Settings/AccountSettings.svelte
+++ b/src/components/Settings/AccountSettings.svelte
@@ -8,7 +8,7 @@
 	const account = createAccountStore();
 </script>
 
-<div class="main-container" in:fly={{y: animationSign * 200, duration: 400}} out:fade={{duration: 100}}>
+<div class="main-container" in:fly|global={{y: animationSign * 200, duration: 400}} out:fade|global={{duration: 100}}>
 	{#if $account?.player}
 		{#if ($account?.player?.playerId < 30000000 || $account?.player?.playerId > 1000000000000000) && !$account?.migrated}
 			<a href="/signin" on:click|preventDefault|stopPropagation={() => navigate('/signin')}>Migrate</a>

--- a/src/components/Settings/LeaderboardSettings.svelte
+++ b/src/components/Settings/LeaderboardSettings.svelte
@@ -284,7 +284,7 @@
 	$: updateProfileSettings($account);
 </script>
 
-<div class="main-container" in:fly={{y: animationSign * 200, duration: 400}} out:fade={{duration: 100}}>
+<div class="main-container" in:fly|global={{y: animationSign * 200, duration: 400}} out:fade|global={{duration: 100}}>
 	<DemoLeaderboardScore playerId={$account?.player?.playerId} selectedMetric={currentScoreBadgeSelected} on:badge-click={onBadgeClick} />
 	<div class="options">
 		<section class="option full">

--- a/src/components/Settings/ProfileUISettings.svelte
+++ b/src/components/Settings/ProfileUISettings.svelte
@@ -73,7 +73,7 @@
 	$: statsHistoryStore.fetchStats(playerData, $configStore.preferences.daysOfHistory);
 </script>
 
-<div class="main-container" in:fly={{y: animationSign * 200, duration: 400}} out:fade={{duration: 100}}>
+<div class="main-container" in:fly|global={{y: animationSign * 200, duration: 400}} out:fade|global={{duration: 100}}>
 	<div class="profile">
 		<Profile playerData={$playerStore} fixedBrowserTitle="Settings" clanEffects={false} />
 		<CardsCarousel {playerId} {playerInfo} {scoresStats} {ssBadges} {playerData} />

--- a/src/components/Settings/RankingSettings.svelte
+++ b/src/components/Settings/RankingSettings.svelte
@@ -24,7 +24,7 @@
 	$: settempsetting('showFriendsButtonOnRanking', currentShowFriendsButton);
 </script>
 
-<div class="main-container" in:fly={{y: animationSign * 200, duration: 400}} out:fade={{duration: 100}}>
+<div class="main-container" in:fly|global={{y: animationSign * 200, duration: 400}} out:fade|global={{duration: 100}}>
 	<div class="profile">
 		<RankingTable page={1} meta={false} editing={true} />
 	</div>

--- a/src/components/Settings/ScoreSettings.svelte
+++ b/src/components/Settings/ScoreSettings.svelte
@@ -280,7 +280,7 @@
 	$: scoreIcons = Object.keys(visibleScoreIcons).filter(key => key !== 'delete');
 </script>
 
-<div class="main-container" in:fly={{y: animationSign * 200, duration: 400}} out:fade={{duration: 100}}>
+<div class="main-container" in:fly|global={{y: animationSign * 200, duration: 400}} out:fade|global={{duration: 100}}>
 	<DemoProfileScore playerId={$account?.player?.playerId} selectedMetric={currentScoreBadgeSelected} on:badge-click={onBadgeClick} />
 	<div class="options">
 		<section class="option full">

--- a/src/components/Settings/Select.svelte
+++ b/src/components/Settings/Select.svelte
@@ -111,8 +111,8 @@
 		<PageOverlay target={header}>
 			<body
 				bind:this={menu}
-				in:fly={{y: -5, duration: 200}}
-				out:fly={{y: -5, duration: 200}}
+				in:fly|global={{y: -5, duration: 200}}
+				out:fly|global={{y: -5, duration: 200}}
 				on:introend={menu.focus()}
 				on:keydown={onKeyDownMenu}
 				tabIndex="0"

--- a/src/components/Settings/ThemeSettings.svelte
+++ b/src/components/Settings/ThemeSettings.svelte
@@ -57,7 +57,7 @@
 	$: settempsetting('theme', currentTheme);
 </script>
 
-<div class="options" in:fly={{y: animationSign * 200, duration: 400}} out:fade={{duration: 100}}>
+<div class="options" in:fly|global={{y: animationSign * 200, duration: 400}} out:fade|global={{duration: 100}}>
 	<section class="option">
 		<label title="Choose the theme you want">Theme</label>
 		<Select bind:value={currentTheme} options={themes}/>

--- a/src/pages/About.svelte
+++ b/src/pages/About.svelte
@@ -27,7 +27,7 @@
 	<title>About - {ssrConfig.name}</title>
 </svelte:head>
 
-<article bind:this={articleEl} transition:fade>
+<article bind:this={articleEl} transition:fade|global>
 	<ContentBox>
 		<h1 class="title is-3">People who keep BeatLeader running</h1>
 		<h1 class="title is-4">Development Team</h1>

--- a/src/pages/Census.svelte
+++ b/src/pages/Census.svelte
@@ -112,7 +112,7 @@
 		title,
 		description: metaDescription,
 		images: [{url: CURRENT_URL + '/assets/census2023.png'}],
-		site_name: ssrConfig.name,
+		siteName: ssrConfig.name,
 	}}
 	twitter={{
 		handle: '@handle',

--- a/src/pages/Clan.svelte
+++ b/src/pages/Clan.svelte
@@ -177,7 +177,7 @@
 			{#if playersPage?.length}
 				<div class="players grid-transition-helper" class:with-icons={isFounder}>
 					{#each playersPage as player, idx (player.playerId)}
-						<div class="ranking-grid-row" in:fly={{delay: idx * 10, x: 100}}>
+						<div class="ranking-grid-row" in:fly|global={{delay: idx * 10, x: 100}}>
 							<PlayerCard
 								{player}
 								playerId={mainPlayerId}

--- a/src/pages/Clans.svelte
+++ b/src/pages/Clans.svelte
@@ -157,7 +157,7 @@
 </svelte:head>
 
 <section class="align-content">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		{#if !createMode && $account?.clan?.id}
 			<ContentBox>
 				<h1 class="title is-5">My clan</h1>
@@ -174,7 +174,7 @@
 					<h2 class="title is-5">Clan requests</h2>
 
 					{#each clanRequests as clan, idx (clan.id)}
-						<section class={`clan-line row-${idx}`} in:fly={{delay: idx * 10, x: 100}}>
+						<section class={`clan-line row-${idx}`} in:fly|global={{delay: idx * 10, x: 100}}>
 							<div class="main" on:click={() => onClanClick(clan)}>
 								<ClanInfo editMode={false} {clan} />
 							</div>
@@ -216,7 +216,7 @@
 			{#if clansPage?.length}
 				<div class="clans grid-transition-helper">
 					{#each clansPage as clan, idx (clan.id)}
-						<div class={`clan-line row-${idx}`} in:fly={{delay: idx * 10, x: 100}}>
+						<div class={`clan-line row-${idx}`} in:fly|global={{delay: idx * 10, x: 100}}>
 							<div class="main" on:click={() => onClanClick(clan)}>
 								<ClanInfoSmall {clan} />
 							</div>

--- a/src/pages/Clans.svelte
+++ b/src/pages/Clans.svelte
@@ -1,5 +1,5 @@
 <script>
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import {createEventDispatcher} from 'svelte';
 	import {fade, fly} from 'svelte/transition';
 	import createClansStore from '../stores/http/http-clans-store';
@@ -16,9 +16,10 @@
 	import ClanInfoSmall from '../components/Clans/ClanInfoSmall.svelte';
 
 	export let page = 1;
-	export let location;
 
 	const FILTERS_DEBOUNCE_MS = 500;
+
+	const location = useLocation();
 
 	document.body.classList.remove('slim');
 	const dispatch = createEventDispatcher();
@@ -28,7 +29,7 @@
 	let createError = null;
 	let createIsSaving = false;
 
-	let shouldBeForceRefreshed = new URLSearchParams(location?.search ?? '')?.get('refresh') ?? false;
+	let shouldBeForceRefreshed = new URLSearchParams($location?.search ?? '')?.get('refresh') ?? false;
 
 	if (page && !Number.isFinite(page)) page = parseInt(page, 10);
 	if (!page || isNaN(page) || page <= 0) page = 1;
@@ -62,7 +63,7 @@
 	};
 
 	let currentPage = page;
-	let currentFilters = buildFiltersFromLocation(location);
+	let currentFilters = buildFiltersFromLocation($location);
 	let boxEl = null;
 
 	const clansStore = createClansStore(page, currentFilters);
@@ -145,7 +146,7 @@
 	$: numOfClans = $clansStore ? $clansStore?.metadata?.total : null;
 	$: itemsPerPage = $clansStore ? $clansStore?.metadata?.itemsPerPage : 10;
 
-	$: changePageAndFilters(page, location, shouldBeForceRefreshed);
+	$: changePageAndFilters(page, $location, shouldBeForceRefreshed);
 
 	$: clanRequests = $account?.clanRequest ?? [];
 

--- a/src/pages/Dashboard.svelte
+++ b/src/pages/Dashboard.svelte
@@ -57,7 +57,7 @@
 		title: ssrConfig.name + ' - Website',
 		description: metaDescription,
 		images: [{url: CURRENT_URL + '/assets/logo-small.png'}],
-		site_name: ssrConfig.name,
+		siteName: ssrConfig.name,
 	}}
 	twitter={{
 		handle: '@handle',

--- a/src/pages/Dashboard.svelte
+++ b/src/pages/Dashboard.svelte
@@ -21,7 +21,7 @@
 	<title>{browserTitle}</title>
 </svelte:head>
 
-<article class="page-content" transition:fade>
+<article class="page-content" transition:fade|global>
 	<div class="columns is-multiline">
 		<div class="content column is-full is-two-fifths-fullhd">
 			<FollowedRanking />

--- a/src/pages/Event.svelte
+++ b/src/pages/Event.svelte
@@ -187,7 +187,7 @@
 		</ContentBox>
 	</aside>
 
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		{#if eventId == 23}
 			<ContentBox cls={modalShown ? 'inner-modal' : ''}>
 				<span>

--- a/src/pages/Event.svelte
+++ b/src/pages/Event.svelte
@@ -1,5 +1,5 @@
 <script>
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import {fade} from 'svelte/transition';
 	import {scrollToTargetAdjusted} from '../utils/browser';
 	import ssrConfig from '../ssr-config';
@@ -19,8 +19,9 @@
 	import {Confetti} from 'svelte-confetti';
 
 	export let page = 1;
-	export let location;
 	export let eventId;
+
+	const location = useLocation();
 
 	const account = createAccountStore();
 
@@ -100,7 +101,7 @@
 	if (!page || isNaN(page) || page <= 0) page = 1;
 
 	let currentPage = page;
-	let currentFilters = buildFiltersFromLocation(location);
+	let currentFilters = buildFiltersFromLocation($location);
 	let currentEventId = eventId;
 	let currentEvent;
 	let boxEl = null;
@@ -171,7 +172,7 @@
 
 	let modalShown;
 
-	$: changeParams(page, eventId, location, true);
+	$: changeParams(page, eventId, $location, true);
 	$: scrollToTop(pending);
 	$: mainPlayerId = $account?.id;
 </script>

--- a/src/pages/Events.svelte
+++ b/src/pages/Events.svelte
@@ -78,7 +78,7 @@
 </svelte:head>
 
 <section class="align-content">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		<ContentBox>
 			<h1 class="title is-5">
 				Events
@@ -99,7 +99,7 @@
 							}}
 							class="event-box"
 							class:finished={Date.now() / 1000 > event?.endDate}
-							in:fade={{delay: idx * 10}}>
+							in:fade|global={{delay: idx * 10}}>
 							<ContentBox cls={event.id == 23 ? 'festive' : ''}>
 								<Event {event} on:show-playlist={e => navigate('/playlist/' + e?.detail?.playlistId)} />
 							</ContentBox>

--- a/src/pages/Events.svelte
+++ b/src/pages/Events.svelte
@@ -1,5 +1,5 @@
 <script>
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import ssrConfig from '../ssr-config';
 	import {fade, fly} from 'svelte/transition';
 	import createEventsStore from '../stores/http/http-events-store';
@@ -9,9 +9,9 @@
 	import Event from '../components/Event/Event.svelte';
 
 	export let page = 1;
-	export let location;
 
-	let shouldBeForceRefreshed = new URLSearchParams(location?.search ?? '')?.get('refresh') ?? false;
+	const location = useLocation();
+	let shouldBeForceRefreshed = new URLSearchParams($location?.search ?? '')?.get('refresh') ?? false;
 
 	if (page && !Number.isFinite(page)) page = parseInt(page, 10);
 	if (!page || isNaN(page) || page <= 0) page = 1;
@@ -39,7 +39,7 @@
 	};
 
 	let currentPage = page;
-	let currentFilters = buildFiltersFromLocation(location);
+	let currentFilters = buildFiltersFromLocation($location);
 
 	const eventsStore = createEventsStore(page, currentFilters);
 
@@ -68,7 +68,7 @@
 	$: numOfEvents = $eventsStore ? $eventsStore?.metadata?.total : null;
 	$: itemsPerPage = $eventsStore ? $eventsStore?.metadata?.itemsPerPage : 10;
 
-	$: changePageAndFilters(page, location, shouldBeForceRefreshed);
+	$: changePageAndFilters(page, $location, shouldBeForceRefreshed);
 
 	$: eventsPage = $eventsStore?.data ?? [];
 </script>

--- a/src/pages/Followed.svelte
+++ b/src/pages/Followed.svelte
@@ -116,8 +116,8 @@
 						<a
 							href={`/u/${f.playerId}`}
 							on:click|preventDefault={() => navigate(`/u/${f.playerId}`)}
-							in:fade={{delay: idx * 20, duration: 200}}
-							out:fade={{duration: 50}}>
+							in:fade|global={{delay: idx * 20, duration: 200}}
+							out:fade|global={{duration: 50}}>
 							<ContentBox cls="friend-box">
 								<div class="friend-container">
 									<span

--- a/src/pages/LandingPage.svelte
+++ b/src/pages/LandingPage.svelte
@@ -33,7 +33,7 @@
 	<title>{ssrConfig.name} - Beat Saber leaderboard</title>
 </svelte:head>
 
-<article class="page-content" transition:fade>
+<article class="page-content" transition:fade|global>
 	<div class="sspl-page-container">
 		<div class="big-landing-box">
 			<div class="cinematics">

--- a/src/pages/LandingPage.svelte
+++ b/src/pages/LandingPage.svelte
@@ -131,7 +131,7 @@
 		title: ssrConfig.name + ' - Beat Saber leaderboard',
 		description: metaDescription,
 		images: [{url: CURRENT_URL + '/assets/logo-small.png'}],
-		site_name: ssrConfig.name,
+		siteName: ssrConfig.name,
 	}}
 	twitter={{
 		handle: '@handle',

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -1,6 +1,6 @@
 <script>
 	import {createEventDispatcher, getContext} from 'svelte';
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import {fade, fly, slide} from 'svelte/transition';
 	import createAccountStore from '../stores/beatleader/account';
 	import createLeaderboardStore from '../stores/http/http-leaderboard-store';
@@ -59,7 +59,6 @@
 	export let leaderboardId;
 	export let type = 'global';
 	export let page = 1;
-	export let location;
 	export let dontNavigate = false;
 	export let withoutDiffSwitcher = false;
 	export let withoutHeader = false;
@@ -73,6 +72,8 @@
 
 	export let autoScrollToTop = true;
 	export let showStats = true;
+
+	const location = useLocation();
 
 	if (!dontNavigate) document.body.classList.add('slim');
 
@@ -147,7 +148,7 @@
 	let currentLeaderboardId = leaderboardId;
 	let currentType = type;
 
-	let currentFilters = buildFiltersFromLocation(location);
+	let currentFilters = buildFiltersFromLocation($location);
 	let leaderboard = null;
 
 	let modifiedPass = null;
@@ -581,7 +582,7 @@
 	$: if (autoScrollToTop) document.body.scrollIntoView({behavior: 'smooth'});
 
 	$: updateParams(leaderboardId, type, page);
-	$: updateFilters(buildFiltersFromLocation(location));
+	$: updateFilters(buildFiltersFromLocation($location));
 
 	$: scores = $leaderboardStore?.scores?.map(s => ({...s, leaderboard: $leaderboardStore?.leaderboard})) ?? null;
 	$: leaderboard = $leaderboardStore?.leaderboard;
@@ -603,7 +604,7 @@
 	$: higlightedPlayerId = higlightedScore?.playerId ?? $account?.id;
 	$: mainPlayerCountry = $account?.player?.playerInfo?.countries?.[0]?.country ?? null;
 
-	$: makeComplexFilters(buildFiltersFromLocation(location), mainPlayerCountry);
+	$: makeComplexFilters(buildFiltersFromLocation($location), mainPlayerCountry);
 
 	$: isAdmin = $account.player && $account.player.playerInfo.role && $account.player.playerInfo.role.includes('admin');
 	$: isRT = isAdmin || ($account.player && $account.player.playerInfo.role && $account.player.playerInfo.role.includes('rankedteam'));

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -658,7 +658,7 @@
 </svelte:head>
 
 <section class="align-content">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		{#if leaderboard && song && !withoutHeader}
 			<ContentBox cls="leaderboard-header-box">
 				<LeaderboardHeader
@@ -711,7 +711,7 @@
 				{/if}
 
 				{#if leaderboardShowSorting}
-					<nav class="switcher-nav" transition:fade>
+					<nav class="switcher-nav" transition:fade|global>
 						<Switcher values={switcherSortValues} value={sortValue} on:change={onSwitcherChanged} />
 						<div style="display: flex;">
 							<ScoreServiceFilters filters={complexFilters} currentFilterValues={currentFilters} on:change={onFiltersChanged} />
@@ -739,8 +739,8 @@
 								class={`row-${idx}`}
 								class:user-score={score?.isUserScore}
 								class:user-score-top={score?.userScoreTop}
-								in:fly={!score?.isUserScore ? {x: 200, delay: idx * 20, duration: 500} : {duration: 300}}
-								out:fade={!score?.isUserScore ? {duration: 100} : {duration: 300}}
+								in:fly|global={!score?.isUserScore ? {x: 200, delay: idx * 20, duration: 500} : {duration: 300}}
+								out:fade|global={!score?.isUserScore ? {duration: 100} : {duration: 300}}
 								animate:flip={score?.isUserScore ? {duration: 300} : {duration: 300}}>
 								<Score
 									{leaderboardId}
@@ -896,7 +896,7 @@
 									<Spinner />
 								</div>
 							{:then beatSavior}
-								<div transition:slide class="tab">
+								<div transition:slide|global class="tab">
 									<BeatSaviorDetails {beatSavior} />
 								</div>
 							{/await}
@@ -909,7 +909,7 @@
 						{/if}
 					{/if}
 				{:else}
-					<p transition:fade>No scores found.</p>
+					<p transition:fade|global>No scores found.</p>
 				{/if}
 			{:else if !$isLoading}
 				<p>Leaderboard not found.</p>
@@ -917,7 +917,7 @@
 		</div>
 	</article>
 	{#if separatePage && type !== 'accsaber'}
-		<aside transition:fade>
+		<aside transition:fade|global>
 			{#if qualification && !isRanked}
 				<ContentBox>
 					{#if !commentaryShown}

--- a/src/pages/Leaderboards.svelte
+++ b/src/pages/Leaderboards.svelte
@@ -771,7 +771,7 @@
 		title: ssrConfig.name + ' - Maps',
 		description: metaDescription,
 		images: [{url: CURRENT_URL + '/assets/logo-small.png'}],
-		site_name: ssrConfig.name,
+		siteName: ssrConfig.name,
 	}}
 	twitter={{
 		handle: '@handle',

--- a/src/pages/Leaderboards.svelte
+++ b/src/pages/Leaderboards.svelte
@@ -1,6 +1,6 @@
 <script>
 	import {tick} from 'svelte';
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import {fade, fly} from 'svelte/transition';
 	import createLeaderboardsStore from '../stores/http/http-leaderboards-store';
 	import createAccountStore from '../stores/beatleader/account';
@@ -45,9 +45,10 @@
 	import Select from '../components/Settings/Select.svelte';
 
 	export let page = 1;
-	export let location;
 
 	const FILTERS_DEBOUNCE_MS = 500;
+
+	const location = useLocation();
 
 	document.body.classList.remove('slim');
 
@@ -98,7 +99,7 @@
 	if (!page || isNaN(page) || page <= 0) page = 1;
 
 	let currentPage = page;
-	let currentFilters = buildFiltersFromLocation(location);
+	let currentFilters = buildFiltersFromLocation($location);
 	let boxEl = null;
 
 	const typeFilterOptions = [
@@ -384,7 +385,7 @@
 
 	$: addAdditionalFilters($account.player && $account.player.playerInfo.mapperId, isRT);
 
-	$: changePageAndFilters(page, location);
+	$: changePageAndFilters(page, $location);
 
 	$: starsKey =
 		currentFilters.sortBy == 'accRating' || currentFilters.sortBy == 'passRating' || currentFilters.sortBy == 'techRating'

--- a/src/pages/Leaderboards.svelte
+++ b/src/pages/Leaderboards.svelte
@@ -440,7 +440,7 @@
 </svelte:head>
 
 <section class="align-content">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		<ContentBox cls="maps-box" bind:box={boxEl}>
 			<h1 class="title is-5">
 				Maps

--- a/src/pages/NotFound.svelte
+++ b/src/pages/NotFound.svelte
@@ -11,7 +11,7 @@
 	<title>404 | You missed - {ssrConfig.name}</title>
 </svelte:head>
 
-<article transition:fade>
+<article transition:fade|global>
 	<ContentBox>
 		<h1 class="title is-3">404 | You Missed</h1>
 

--- a/src/pages/OauthSignIn.svelte
+++ b/src/pages/OauthSignIn.svelte
@@ -1,4 +1,5 @@
 <script>
+	import {useLocation} from 'svelte-routing';
 	import Button from '../components/Common/Button.svelte';
 	import createAccountStore from '../stores/beatleader/account';
 	import createOculusStore from '../stores/beatleader/oculususer';
@@ -10,9 +11,9 @@
 	import ContentBox from '../components/Common/ContentBox.svelte';
 	import {fetchJson} from '../network/fetch';
 
-	export let location;
+	const location = useLocation();
 
-	const searchParams = new URLSearchParams(location?.search ?? '');
+	const searchParams = new URLSearchParams($location?.search ?? '');
 
 	const account = createAccountStore();
 	const oculus = createOculusStore();
@@ -104,17 +105,17 @@
 			<p class="error">{error}</p>
 		{/if}
 
-		<Button iconFa="fas fa-plus-square" label="Login" on:click={() => account.logIn(login, password, window.location.search)} />
+		<Button iconFa="fas fa-plus-square" label="Login" on:click={() => account.logIn(login, password, $location.search)} />
 		<form action={BL_API_URL + 'signin'} method="post">
 			<input type="hidden" name="Provider" value="Steam" />
-			<input type="hidden" name="oauthState" value={window.location.search} />
+			<input type="hidden" name="oauthState" value={$location.search} />
 			<input type="hidden" name="ReturnUrl" value={CURRENT_URL} />
 
 			<Button icon={steamSvg} label="Login with Steam" type="submit" />
 		</form>
 		<form action={BL_API_URL + 'signin'} method="post">
 			<input type="hidden" name="Provider" value="BeatSaver" />
-			<input type="hidden" name="oauthState" value={window.location.search} />
+			<input type="hidden" name="oauthState" value={$location.search} />
 			<input type="hidden" name="ReturnUrl" value={CURRENT_URL} />
 
 			<Button icon={beatSaverSvg} label="Login with BeatSaver" type="submit" />

--- a/src/pages/Player.svelte
+++ b/src/pages/Player.svelte
@@ -1,6 +1,6 @@
 <script>
 	import {onMount} from 'svelte';
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import {fade} from 'svelte/transition';
 	import createPlayerInfoWithScoresStore from '../stores/http/http-player-with-scores-store';
 	import createTwitchService from '../services/twitch';
@@ -33,7 +33,8 @@
 
 	export let initialPlayerId = null;
 	export let initialParams = null;
-	export let location = null;
+
+	const location = useLocation();
 
 	let service = null;
 	let serviceParams = null;
@@ -209,7 +210,7 @@
 	$: pinnedScoresStore.fetchScores(playerData?.playerId);
 	$: statsHistoryStore.fetchStats(playerData, $configStore.preferences.daysOfHistory);
 
-	$: editing = new URLSearchParams(location?.search).get('edit') ?? null;
+	$: editing = new URLSearchParams($location?.search).get('edit') ?? null;
 </script>
 
 <svelte:head>

--- a/src/pages/Player.svelte
+++ b/src/pages/Player.svelte
@@ -219,7 +219,7 @@
 <svelte:window bind:innerWidth bind:innerHeight />
 
 <section class="align-content player-page">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		{#if $playerError && ($playerError instanceof SsrHttpNotFoundError || $playerError instanceof SsrHttpUnprocessableEntityError)}
 			<ContentBox>
 				<p class="error">Player not found.</p>

--- a/src/pages/Privacy.svelte
+++ b/src/pages/Privacy.svelte
@@ -20,7 +20,7 @@
 	<title>Privacy policy - {ssrConfig.name}</title>
 </svelte:head>
 
-<article bind:this={articleEl} transition:fade>
+<article bind:this={articleEl} transition:fade|global>
 	<ContentBox>
 		<h1 class="title is-3">Privacy policy</h1>
 

--- a/src/pages/Ranking.svelte
+++ b/src/pages/Ranking.svelte
@@ -347,7 +347,7 @@
 </svelte:head>
 
 <section class="align-content">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		<!-- <ContentBox cls="event-banner" on:click={() => navigate('/event/37')}>
 			<div class="event-container">
 				<img alt="Event banner" class="event-image" src="https://cdn.assets.beatleader.xyz/23594-event.png" />

--- a/src/pages/Ranking.svelte
+++ b/src/pages/Ranking.svelte
@@ -1,5 +1,5 @@
 <script>
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import {fade} from 'svelte/transition';
 	import {
 		createBuildFiltersFromLocation,
@@ -18,16 +18,17 @@
 	import Countries from '../components/Ranking/Countries.svelte';
 	import Headsets from '../components/Ranking/Headsets.svelte';
 	import BackToTop from '../components/Common/BackToTop.svelte';
-	import Button from '../components/Common/Button.svelte';
 	import {configStore} from '../stores/config';
+
 	import produce from 'immer';
 
 	export let page = 1;
-	export let location;
 
 	document.body.classList.remove('slim');
 
 	const FILTERS_DEBOUNCE_MS = 500;
+
+	const location = useLocation();
 
 	const findParam = key => params.find(p => p.key === key);
 
@@ -242,7 +243,7 @@
 	if (!page || isNaN(page) || page <= 0) page = 1;
 
 	let currentPage = page;
-	let currentFilters = buildFiltersFromLocation(location);
+	let currentFilters = buildFiltersFromLocation($location);
 	let boxEl = null;
 
 	let isLoading = false;
@@ -337,7 +338,7 @@
 	}
 
 	$: document.body.scrollIntoView({behavior: 'smooth'});
-	$: changeParams(page, location, true);
+	$: changeParams(page, $location, true);
 
 	$: showFilters = $configStore.preferences.showFiltersOnRanking;
 </script>

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -88,7 +88,7 @@
 </svelte:head>
 
 <section class="align-content">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		{#if configStore && $configStore}
 			<ContentBox>
 				<h1 class="header-title">Settings</h1>

--- a/src/pages/StaffDashboard.svelte
+++ b/src/pages/StaffDashboard.svelte
@@ -1,6 +1,6 @@
 <script>
 	import {fade} from 'svelte/transition';
-	import {navigate} from 'svelte-routing';
+	import {navigate, useLocation} from 'svelte-routing';
 	import createAccountStore from '../stores/beatleader/account';
 	import createLocalStorageStore from '../stores/localstorage';
 	import leaderboardsApiClient from '../network/clients/beatleader/leaderboard/api-leaderboards';
@@ -33,9 +33,8 @@
 	import {Ranked_Const} from './../utils/beatleader/consts';
 	import Reveal from '../components/Common/Reveal.svelte';
 	import QualityInfo from '../components/Leaderboard/QualityVotes/QualityInfo.svelte';
-	import Pager from '../components/Common/Pager.svelte';
 
-	export let location;
+	const location = useLocation();
 
 	document.body.classList.add('remove');
 
@@ -508,7 +507,7 @@
 		navigate(`/staff?${buildSearchFromFilters(currentFilters)}`, {replace});
 	}
 
-	let currentFilters = buildFiltersFromLocation(location);
+	let currentFilters = buildFiltersFromLocation($location);
 
 	let error = null;
 	let isLoading = true;

--- a/src/pages/StaffDashboard.svelte
+++ b/src/pages/StaffDashboard.svelte
@@ -1205,7 +1205,7 @@
 </svelte:head>
 
 <section class="align-content">
-	<article class="page-content" transition:fade>
+	<article class="page-content" transition:fade|global>
 		<ContentBox>
 			<h1 class="title is-3">
 				{#if !error && !isLoading}

--- a/src/pages/Support.svelte
+++ b/src/pages/Support.svelte
@@ -20,7 +20,7 @@
 	<title>Help - {ssrConfig.name}</title>
 </svelte:head>
 
-<article bind:this={articleEl} transition:fade>
+<article bind:this={articleEl} transition:fade|global>
 	<ContentBox>
 		<h1 class="title is-3">Help</h1>
 

--- a/src/pages/Twitch.svelte
+++ b/src/pages/Twitch.svelte
@@ -47,7 +47,7 @@
 	<title>Twitch integration | {ssrConfig.name}</title>
 </svelte:head>
 
-<article transition:fade>
+<article transition:fade|global>
 	<ContentBox>
 		<h1 class="title is-3">Twitch integration</h1>
 

--- a/src/stores/beatleader/stats-history.js
+++ b/src/stores/beatleader/stats-history.js
@@ -12,7 +12,7 @@ export default () => {
 	let votingStatuses = {};
 
 	const get = () => votingStatuses;
-	const {subscribe: subscribeState, set} = writable(votingStatuses);
+	const {subscribe: subscribeState, set, update} = writable(votingStatuses);
 
 	const fetchStats = async (playerData, count = 50) => {
 		if (!playerData) return;
@@ -88,6 +88,7 @@ export default () => {
 		subscribe,
 		get,
 		set,
+		update,
 		fetchStats,
 	};
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -186,6 +186,8 @@ export default async () => {
 		return newConfig;
 	};
 
+	const update = fn => set(fn(currentConfig));
+
 	const setForKey = async (key, value, persist = true) => {
 		currentConfig[key] = value;
 
@@ -195,7 +197,6 @@ export default async () => {
 		}
 
 		settingsChanged = !deepEqual(currentConfig, dbConfig);
-		currentConfig = currentConfig;
 		storeSet(currentConfig);
 
 		return currentConfig;
@@ -260,6 +261,7 @@ export default async () => {
 	configStore = {
 		subscribe,
 		set,
+		update,
 		get,
 		getLocale,
 		setForKey,

--- a/src/stores/localstorage.js
+++ b/src/stores/localstorage.js
@@ -3,19 +3,24 @@ import {writable} from 'svelte/store';
 export default (key, initial = {}, prefix = 'bl-') => {
 	const lsKey = `${prefix}-${key}`;
 
-	const value = JSON.parse(localStorage.getItem(lsKey)) ?? initial;
+	let value = JSON.parse(localStorage.getItem(lsKey)) ?? initial;
 
 	const {subscribe, unsubscribe, set: storeSet} = writable(value ?? initial);
 
-	const set = value => {
-		localStorage.setItem(lsKey, JSON.stringify(value));
+	const set = newValue => {
+		localStorage.setItem(lsKey, JSON.stringify(newValue));
 
-		storeSet(value);
+		value = newValue;
+
+		storeSet(newValue);
 	};
+
+	const update = fn => set(fn(value));
 
 	return {
 		subscribe,
 		unsubscribe,
 		set,
+		update,
 	};
 };

--- a/src/stores/playlists.js
+++ b/src/stores/playlists.js
@@ -53,6 +53,8 @@ export default () => {
 		return newConfig;
 	};
 
+	const update = fn => set(fn(playlists));
+
 	const create = async (song = null, inputPlaylist = null) => {
 		const playlist = inputPlaylist
 			? inputPlaylist
@@ -290,6 +292,7 @@ export default () => {
 		subscribe,
 		unsubscribe,
 		set,
+		update,
 		get,
 		create,
 		select,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,46 +11,42 @@
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@babel/code-frame@^7.10.4":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
-  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
+  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
   dependencies:
-    "@babel/highlight" "^7.18.6"
+    "@babel/highlight" "^7.22.13"
+    chalk "^2.4.2"
 
-"@babel/helper-validator-identifier@^7.18.6":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
-  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
-"@babel/highlight@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
-  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
+"@babel/highlight@^7.22.13":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.13.tgz#9cda839e5d3be9ca9e8c26b6dd69e7548f0cbf16"
+  integrity sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.18.6"
-    chalk "^2.0.0"
+    "@babel/helper-validator-identifier" "^7.22.5"
+    chalk "^2.4.2"
     js-tokens "^4.0.0"
 
 "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
-  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  version "7.22.11"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.11.tgz#7a9ba3bbe406ad6f9e8dd4da2ece453eb23a77a4"
+  integrity sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==
   dependencies:
-    regenerator-runtime "^0.13.11"
+    regenerator-runtime "^0.14.0"
 
 "@jridgewell/gen-mapping@^0.3.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
+  integrity sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==
   dependencies:
     "@jridgewell/set-array" "^1.0.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
-
-"@jridgewell/resolve-uri@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
@@ -62,39 +58,26 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/source-map@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
-  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.5.tgz#a3bb4d5c6825aab0d281268f47f6ad5853431e91"
+  integrity sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==
   dependencies:
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
-"@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18":
+"@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.19"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz#f8a3249862f91be48d3127c3cfe992f79b4b8811"
   integrity sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.17"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
-  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
-  dependencies:
-    "@jridgewell/resolve-uri" "3.1.0"
-    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -123,9 +106,9 @@
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
 "@popperjs/core@^2.11.6":
-  version "2.11.6"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
-  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
 "@rollup/plugin-commonjs@^17.0.0":
   version "17.1.0"
@@ -182,25 +165,20 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/svelte/-/svelte-1.0.13.tgz#2fa34376627192c0d643ce54964915e2bd3a58e4"
   integrity sha512-5lYJP45Xllo4yE/RUBccBT32eBlRDbqN8r1/MIvQbKxW3aFqaYPCNgm8D5V20X4ShHcwvYWNlKg3liDh1MlBoA==
 
-"@types/estree@*":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.0.tgz#5fb2e536c1ae9bf35366eed879e827fa59ca41c2"
-  integrity sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==
+"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/estree@^1.0.0", "@types/estree@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
-  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
-
 "@types/node@*":
-  version "18.14.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"
-  integrity sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==
+  version "20.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
+  integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
 "@types/pug@^2.0.6":
   version "2.0.6"
@@ -214,15 +192,10 @@
   dependencies:
     "@types/node" "*"
 
-acorn@^8.10.0, acorn@^8.9.0:
+acorn@^8.10.0, acorn@^8.8.2, acorn@^8.9.0:
   version "8.10.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
   integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
-
-acorn@^8.5.0:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
-  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -245,6 +218,14 @@ aria-query@^5.3.0:
   integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
   dependencies:
     dequal "^2.0.3"
+
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+  dependencies:
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
 
 atropos@^1.0.2:
   version "1.0.2"
@@ -348,7 +329,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-chalk@^2.0.0:
+chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -462,15 +443,16 @@ css-tree@^2.3.1:
   resolved "https://github.com/claap-app/custom-protocol-check.git#90d9ba85520039863b3a73fdde1393a6ca39db98"
 
 deep-equal@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.0.tgz#5caeace9c781028b9ff459f33b779346637c43e6"
-  integrity sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.2.tgz#9b2635da569a13ba8e1cc159c2f744071b115daa"
+  integrity sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==
   dependencies:
+    array-buffer-byte-length "^1.0.0"
     call-bind "^1.0.2"
-    es-get-iterator "^1.1.2"
-    get-intrinsic "^1.1.3"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.1"
     is-arguments "^1.1.1"
-    is-array-buffer "^3.0.1"
+    is-array-buffer "^3.0.2"
     is-date-object "^1.0.5"
     is-regex "^1.1.4"
     is-shared-array-buffer "^1.0.2"
@@ -478,18 +460,18 @@ deep-equal@^2.2.0:
     object-is "^1.1.5"
     object-keys "^1.1.1"
     object.assign "^4.1.4"
-    regexp.prototype.flags "^1.4.3"
+    regexp.prototype.flags "^1.5.0"
     side-channel "^1.0.4"
     which-boxed-primitive "^1.0.2"
     which-collection "^1.0.1"
     which-typed-array "^1.1.9"
 
 deepmerge@^4.2.2:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.0.tgz#65491893ec47756d44719ae520e0e2609233b59b"
-  integrity sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
-define-properties@^1.1.3, define-properties@^1.1.4:
+define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
   integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
@@ -526,7 +508,7 @@ errno@^0.1.1:
   dependencies:
     prr "~1.0.1"
 
-es-get-iterator@^1.1.2:
+es-get-iterator@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
   integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
@@ -584,9 +566,9 @@ eventemitter3@^4.0.7:
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 fake-indexeddb@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-4.0.1.tgz#09bb2468e21d0832b2177e894765fb109edac8fb"
-  integrity sha512-hFRyPmvEZILYgdcLBxVdHLik4Tj3gDTu/g7s9ZDOiU3sTNiGx+vEu1ri/AMsFJUZ/1sdRbAVrEcKndh3sViBcA==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-4.0.2.tgz#e7a884158fa576e00f03e973b9874619947013e4"
+  integrity sha512-SdTwEhnakbgazc7W3WUXOJfGmhH0YfG4d+dRPOFoYDRTL6U5t8tvrmkf2W/C3W1jk2ylV7Wrnj44RASqpX/lEw==
   dependencies:
     realistic-structured-clone "^3.0.0"
 
@@ -639,27 +621,28 @@ fs.realpath@^1.0.0:
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-functions-have-names@^1.2.2:
+functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
-  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
+    has-proto "^1.0.1"
     has-symbols "^1.0.3"
 
 get-port@^3.2.0:
@@ -694,9 +677,9 @@ gopd@^1.0.1:
     get-intrinsic "^1.1.3"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.2.10"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
-  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 growl@>=1.10.0:
   version "1.10.5"
@@ -730,6 +713,11 @@ has-property-descriptors@^1.0.0:
   dependencies:
     get-intrinsic "^1.1.1"
 
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+
 has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
@@ -760,9 +748,9 @@ image-size@~0.5.0:
   integrity sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==
 
 immer@^9.0.5:
-  version "9.0.19"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.19.tgz#67fb97310555690b5f9cd8380d38fc0aabb6b38b"
-  integrity sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 import-fresh@^3.2.1:
   version "3.3.0"
@@ -802,7 +790,7 @@ is-arguments@^1.1.1:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-array-buffer@^3.0.1:
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
   integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
@@ -838,10 +826,10 @@ is-callable@^1.1.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
-is-core-module@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+is-core-module@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
   dependencies:
     has "^1.0.3"
 
@@ -935,15 +923,11 @@ is-symbol@^1.0.3:
     has-symbols "^1.0.2"
 
 is-typed-array@^1.1.10:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
-  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.12.tgz#d0bab5686ef4a76f7a73097b95470ab199c57d4a"
+  integrity sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==
   dependencies:
-    available-typed-arrays "^1.0.5"
-    call-bind "^1.0.2"
-    for-each "^0.3.3"
-    gopd "^1.0.1"
-    has-tostringtag "^1.0.0"
+    which-typed-array "^1.1.11"
 
 is-weakmap@^2.0.1:
   version "2.0.1"
@@ -1287,9 +1271,9 @@ prettier-plugin-svelte@^2.10.1:
   integrity sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==
 
 prettier@^2.8.1:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
-  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 prr@~1.0.1:
   version "1.0.1"
@@ -1334,19 +1318,19 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.11:
-  version "0.13.11"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
-  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
-regexp.prototype.flags@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
-  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+regexp.prototype.flags@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    functions-have-names "^1.2.2"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -1354,16 +1338,16 @@ resolve-from@^4.0.0:
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve.exports@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.1.tgz#cee884cd4e3f355660e501fa3276b27d7ffe5a20"
-  integrity sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
+  integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
 resolve@^1.17.0, resolve@^1.19.0:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.4.tgz#1dc40df46554cdaf8948a486a10f6ba1e2026c34"
+  integrity sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==
   dependencies:
-    is-core-module "^2.9.0"
+    is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -1514,9 +1498,9 @@ semiver@^1.0.0:
   integrity sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==
 
 semver@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 serialize-javascript@^4.0.0:
   version "4.0.0"
@@ -1617,9 +1601,9 @@ strip-indent@^3.0.0:
     min-indent "^1.0.0"
 
 suneditor@^2.44.3:
-  version "2.44.3"
-  resolved "https://registry.yarnpkg.com/suneditor/-/suneditor-2.44.3.tgz#dd928c37fd82d58414b8d34aa70b8b3cdbc9d39a"
-  integrity sha512-B25DrbAxcwkvAANNm2EClugBCxATCa3SvV03SpyaMJybKj4bzQnS1iq6Wo3h+v970tNSnjfeoT3ID3Nj0NuiBA==
+  version "2.45.1"
+  resolved "https://registry.yarnpkg.com/suneditor/-/suneditor-2.45.1.tgz#5ce56a2d67bfd31e2c21f777cc7f5a522631eb06"
+  integrity sha512-fLxc0nLwd77vaPuf78D+VAFNAgX9hLps6h96JA/LUCpqt4LeYnEaIE1RfJojX+BhSA+krl5qZ8pdgqcoo3dN3g==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -1660,9 +1644,9 @@ svelte-check@^3.4.3:
     typescript "^5.0.3"
 
 svelte-confetti@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/svelte-confetti/-/svelte-confetti-1.2.2.tgz#87e96d19ce859af40b099535cfd406bf38245770"
-  integrity sha512-LkvWO732jRNmYykWi0IOK7xoBX241p+p+tC7Ef1EcO3TK9b9lpB/vYqKkcwVya+onG2SgQsX2g+JVbVKxq5ixQ==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/svelte-confetti/-/svelte-confetti-1.3.0.tgz#c9b1d4e2e72eba5f58324be9f4e1d59870823c49"
+  integrity sha512-Ip1ch72ge/wopwZ5KDnJCEg4AtLfUYdURDrlxV4MiGKFduRZvyuXq1vl1KKTNr84dBhZxSZ8h0Sl4Sdtmdmtiw==
 
 svelte-dnd-action@^0.9.26:
   version "0.9.26"
@@ -1693,9 +1677,9 @@ svelte-preprocess@^5.0.3, svelte-preprocess@^5.0.4:
     strip-indent "^3.0.0"
 
 svelte-range-slider-pips@^2.0.3:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/svelte-range-slider-pips/-/svelte-range-slider-pips-2.1.1.tgz#21c188e3a3c350eeb5fa978b7b6816f7044032bc"
-  integrity sha512-fLkhfnyEc4uMOCZCl8IPyC0e9lujrjqdSyrKw28Y8j99YUPZR+pHnSxde7PqhM0ST6eyO4ugh2nFnLZTIoG9aQ==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/svelte-range-slider-pips/-/svelte-range-slider-pips-2.2.2.tgz#1622acbfe0e517aaf18d571dcff0a18b6e85cce6"
+  integrity sha512-SsiIBpCkBnqvfaHLeIDolTfZlc8m7y93MhlxPKQ90YMZnE/rAxj+IoCrd7LTL/nXA2SCla4IJutSzfwdOtJddA==
 
 svelte-routing@2.1.0:
   version "2.1.0"
@@ -1732,12 +1716,12 @@ svelte@^4.0.0:
     periscopic "^3.1.0"
 
 terser@^5.0.0:
-  version "5.16.5"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.5.tgz#1c285ca0655f467f92af1bbab46ab72d1cb08e5a"
-  integrity sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==
+  version "5.19.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.19.2.tgz#bdb8017a9a4a8de4663a7983f45c506534f9234e"
+  integrity sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==
   dependencies:
-    "@jridgewell/source-map" "^0.3.2"
-    acorn "^8.5.0"
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
@@ -1771,9 +1755,9 @@ tslib@^1.10.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 typescript@^5.0.0, typescript@^5.0.3:
   version "5.2.2"
@@ -1842,17 +1826,16 @@ which-collection@^1.0.1:
     is-weakmap "^2.0.1"
     is-weakset "^2.0.1"
 
-which-typed-array@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
-  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+which-typed-array@^1.1.11, which-typed-array@^1.1.9:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.11.tgz#99d691f23c72aab6768680805a271b69761ed61a"
+  integrity sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==
   dependencies:
     available-typed-arrays "^1.0.5"
     call-bind "^1.0.2"
     for-each "^0.3.3"
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
-    is-typed-array "^1.1.10"
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
+  integrity sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@babel/code-frame@^7.10.4":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -44,6 +52,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
+  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
+
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -62,6 +75,19 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
+"@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
+  version "1.4.15"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
+  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz#f8a3249862f91be48d3127c3cfe992f79b4b8811"
+  integrity sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
@@ -69,6 +95,27 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.5"
+    fastq "^1.6.0"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -145,12 +192,17 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/estree@^1.0.0", "@types/estree@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
+  integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
+
 "@types/node@*":
   version "18.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"
   integrity sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==
 
-"@types/pug@^2.0.4":
+"@types/pug@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.6.tgz#f830323c88172e66826d0bde413498b61054b5a6"
   integrity sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==
@@ -162,12 +214,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/sass@^1.16.0":
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.45.0.tgz#a949eb1e080ff34715e6c2040357b940bffb89bb"
-  integrity sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==
-  dependencies:
-    sass "*"
+acorn@^8.10.0, acorn@^8.9.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 acorn@^8.5.0:
   version "8.8.2"
@@ -181,13 +231,6 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.1.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  dependencies:
-    color-convert "^2.0.1"
-
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -195,6 +238,13 @@ anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+aria-query@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 atropos@^1.0.2:
   version "1.0.2"
@@ -205,6 +255,13 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axobject-query@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.1.tgz#39c378a6e3b06ca679f29138151e45b2b32da62a"
+  integrity sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==
+  dependencies:
+    dequal "^2.0.3"
 
 babel-runtime@^6.26.0:
   version "6.26.0"
@@ -242,7 +299,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -300,14 +357,6 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chart.js@^3.5.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.9.1.tgz#3abf2c775169c4c71217a107163ac708515924b8"
@@ -325,7 +374,7 @@ chartjs-plugin-zoom@^1.1.1:
   dependencies:
     hammerjs "^2.0.8"
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.1, chokidar@^3.5.0:
+chokidar@^3.4.1, chokidar@^3.5.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -340,6 +389,17 @@ chartjs-plugin-zoom@^1.1.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+code-red@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/code-red/-/code-red-1.0.4.tgz#59ba5c9d1d320a4ef795bc10a28bd42bfebe3e35"
+  integrity sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+    "@types/estree" "^1.0.1"
+    acorn "^8.10.0"
+    estree-walker "^3.0.3"
+    periscopic "^3.1.0"
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -347,22 +407,10 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
-color-convert@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
-  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
-  dependencies:
-    color-name "~1.1.4"
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 comlink@^4.3.1:
   version "4.4.1"
@@ -401,14 +449,17 @@ core-js@^2.4.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
+css-tree@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
+
 "custom-protocol-check@https://github.com/claap-app/custom-protocol-check.git":
   version "1.4.0"
   resolved "https://github.com/claap-app/custom-protocol-check.git#90d9ba85520039863b3a73fdde1393a6ca39db98"
-
-dedent-js@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dedent-js/-/dedent-js-1.0.1.tgz#bee5fb7c9e727d85dffa24590d10ec1ab1255305"
-  integrity sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==
 
 deep-equal@^2.2.0:
   version "2.2.0"
@@ -446,7 +497,12 @@ define-properties@^1.1.3, define-properties@^1.1.4:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-detect-indent@^6.0.0:
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-indent@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
@@ -515,6 +571,13 @@ estree-walker@^2.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.0, estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -526,6 +589,24 @@ fake-indexeddb@^4.0.1:
   integrity sha512-hFRyPmvEZILYgdcLBxVdHLik4Tj3gDTu/g7s9ZDOiU3sTNiGx+vEu1ri/AMsFJUZ/1sdRbAVrEcKndh3sViBcA==
   dependencies:
     realistic-structured-clone "^3.0.0"
+
+fast-glob@^3.2.7:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fastq@^1.6.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
+  dependencies:
+    reusify "^1.0.4"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -586,7 +667,7 @@ get-port@^3.2.0:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
   integrity sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==
 
-glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -682,11 +763,6 @@ immer@^9.0.5:
   version "9.0.19"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.19.tgz#67fb97310555690b5f9cd8380d38fc0aabb6b38b"
   integrity sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==
-
-immutable@^4.0.0:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.2.4.tgz#83260d50889526b4b531a5e293709a77f7c55a2a"
-  integrity sha512-WDxL3Hheb1JkRN3sQkyujNlL/xRjAo3rJtaU5xeufUauG66JdMr32bLj4gF+vWl84DIA3Zxw7tiAjneYzRRw+w==
 
 import-fresh@^3.2.1:
   version "3.3.0"
@@ -814,6 +890,13 @@ is-reference@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
   integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
+
+is-reference@^3.0.0, is-reference@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-3.0.1.tgz#d400f4260f7e55733955e60d361d827eb4d3b831"
+  integrity sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==
   dependencies:
     "@types/estree" "*"
 
@@ -971,17 +1054,15 @@ local-access@^1.0.1:
   resolved "https://registry.yarnpkg.com/local-access/-/local-access-1.1.0.tgz#e007c76ba2ca83d5877ba1a125fc8dfe23ba4798"
   integrity sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==
 
+locate-character@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-3.0.0.tgz#0305c5b8744f61028ef5d01f444009e00779f974"
+  integrity sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==
+
 lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lower-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
-  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
-  dependencies:
-    tslib "^2.0.3"
 
 luxon@^2.0.2:
   version "2.5.2"
@@ -995,6 +1076,20 @@ magic-string@^0.25.2, magic-string@^0.25.7:
   dependencies:
     sourcemap-codec "^1.4.8"
 
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
+
+magic-string@^0.30.0:
+  version "0.30.3"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.3.tgz#403755dfd9d6b398dfa40635d52e96c5ac095b85"
+  integrity sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -1003,10 +1098,28 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
 
 microseconds@0.2.0:
   version "0.2.0"
@@ -1030,7 +1143,7 @@ minimatch@^3.0.2, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -1063,14 +1176,6 @@ native-request@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/native-request/-/native-request-1.1.0.tgz#acdb30fe2eefa3e1bc8c54b3a6852e9c5c0d3cb0"
   integrity sha512-uZ5rQaeRn15XmpgE0xoPL8YWqcX90VtCFglYwAgkvKM5e8fog+vePLAhHxuuv/gRkrQxIeh5U3q9sMNUrENqWw==
-
-no-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
-  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
-  dependencies:
-    lower-case "^2.0.2"
-    tslib "^2.0.3"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -1142,14 +1247,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-pascal-case@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
-  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -1160,7 +1257,21 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2:
+periscopic@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/periscopic/-/periscopic-3.1.0.tgz#7e9037bf51c5855bd33b48928828db4afa79d97a"
+  integrity sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^3.0.0"
+    is-reference "^3.0.0"
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -1170,10 +1281,10 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-prettier-plugin-svelte@^2.7.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.9.0.tgz#16cc7fa73fa96eaef48b44089753ac9f1f1175e5"
-  integrity sha512-3doBi5NO4IVgaNPtwewvrgPpqAcvNv0NwJNflr76PIGgi9nf1oguQV1Hpdm9TI2ALIQVn/9iIwLpBO5UcD2Jiw==
+prettier-plugin-svelte@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.1.tgz#e1abbe5689e8a926c60b8bc42e61233556ca90d1"
+  integrity sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==
 
 prettier@^2.8.1:
   version "2.8.4"
@@ -1189,6 +1300,11 @@ punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -1251,6 +1367,11 @@ resolve@^1.17.0, resolve@^1.19.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -1299,10 +1420,10 @@ rollup-plugin-replace@^2.2.0:
     magic-string "^0.25.2"
     rollup-pluginutils "^2.6.0"
 
-rollup-plugin-svelte@^7.0.0:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-svelte/-/rollup-plugin-svelte-7.1.4.tgz#abd71aebe709c3d5f1e50ad98d9399ee18bdeb41"
-  integrity sha512-Jm0FCydR7k8bBGe7wimXAes8x2zEK10Ew3f3lEZwYor/Zya3X0AZVeSAPRH7yiXB9hWQVzJu597EUeNwGDTdjQ==
+rollup-plugin-svelte@^7.1.5:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-svelte/-/rollup-plugin-svelte-7.1.6.tgz#44a4ea6c6e8ed976824d9fd40c78d048515e5838"
+  integrity sha512-nVFRBpGWI2qUY1OcSiEEA/kjCY2+vAjO9BI8SzA7NRrh2GTunLd6w2EYmnMt/atgdg8GvcNjLsmZmbQs/u4SQA==
   dependencies:
     "@rollup/pluginutils" "^4.1.0"
     resolve.exports "^2.0.0"
@@ -1353,6 +1474,13 @@ rollup@^2.3.4:
   optionalDependencies:
     fsevents "~2.3.2"
 
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
+
 sade@^1.6.0, sade@^1.7.4:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
@@ -1375,16 +1503,7 @@ sander@^0.5.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-sass@*:
-  version "1.58.3"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.58.3.tgz#2348cc052061ba4f00243a208b09c40e031f270d"
-  integrity sha512-Q7RaEtYf6BflYrQ+buPudKR26/lH+10EmO9bBqbmPh/KeLqv8bjpTNqxe71ocONqXq+jYiCbpPUmQMS+JJPk4A==
-  dependencies:
-    chokidar ">=3.0.0 <4.0.0"
-    immutable "^4.0.0"
-    source-map-js ">=0.6.2 <2.0.0"
-
-schema-dts@^1.1.0:
+schema-dts@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/schema-dts/-/schema-dts-1.1.2.tgz#82ccf71b5dcb80065a1cc5941888507a4ce1e44b"
   integrity sha512-MpNwH0dZJHinVxk9bT8XUdjKTxMYrA5bLtrrGmFA6PTLwlOKnhi67XoRd6/ty+Djt6ZC0slR57qFhZDNMI6DhQ==
@@ -1438,17 +1557,17 @@ sirv@^1.0.13:
     mrmime "^1.0.0"
     totalist "^1.0.0"
 
-sorcery@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/sorcery/-/sorcery-0.10.0.tgz#8ae90ad7d7cb05fc59f1ab0c637845d5c15a52b7"
-  integrity sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==
+sorcery@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/sorcery/-/sorcery-0.11.0.tgz#310c80ee993433854bb55bb9aa4003acd147fca8"
+  integrity sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==
   dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.14"
     buffer-crc32 "^0.2.5"
     minimist "^1.2.0"
     sander "^0.5.0"
-    sourcemap-codec "^1.3.0"
 
-"source-map-js@>=0.6.2 <2.0.0":
+source-map-js@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -1478,12 +1597,7 @@ source-map@^0.6.0, source-map@~0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
-  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
-
-sourcemap-codec@^1.3.0, sourcemap-codec@^1.4.8:
+sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -1514,7 +1628,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -1531,48 +1645,51 @@ svelte-chartjs@^3.1.2:
   resolved "https://registry.yarnpkg.com/svelte-chartjs/-/svelte-chartjs-3.1.2.tgz#741114fcf8168615535de33b360a6bafcee2344e"
   integrity sha512-3+6gY2IJ9Ua8R9pk3iS1ypa7Z9OoXCJb9oPwIfTp7caJM+X+RrWnH2CTkGAq7FeSxc2nnmW08tYN88Q8Y+5M+w==
 
-svelte-check@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-1.6.0.tgz#fcc7b28252a89be0e4cd369c58bbf8e76e81295f"
-  integrity sha512-nQTlbFJWhwoeLY5rkhgbjzGQSwk5F1pRdEXait0EFaQSrE/iJF+PIjrQlk0BjL/ogk9HaR9ZI0DQSYrl7jl3IQ==
+svelte-check@^3.4.3:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-3.5.1.tgz#88265b41623b9374ff35b69802497287073d693d"
+  integrity sha512-+Zb4iHxAhdUtcUg/WJPRjlS1RJalIsWAe9Mz6G1zyznSs7dDkT7VUBdXc3q7Iwg49O/VrZgyJRvOJkjuBfKjFA==
   dependencies:
-    chalk "^4.0.0"
+    "@jridgewell/trace-mapping" "^0.3.17"
     chokidar "^3.4.1"
-    glob "^7.1.6"
+    fast-glob "^3.2.7"
     import-fresh "^3.2.1"
-    minimist "^1.2.5"
+    picocolors "^1.0.0"
     sade "^1.7.4"
-    source-map "^0.7.3"
-    svelte-preprocess "^4.0.0"
-    typescript "*"
+    svelte-preprocess "^5.0.4"
+    typescript "^5.0.3"
 
 svelte-confetti@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/svelte-confetti/-/svelte-confetti-1.2.2.tgz#87e96d19ce859af40b099535cfd406bf38245770"
   integrity sha512-LkvWO732jRNmYykWi0IOK7xoBX241p+p+tC7Ef1EcO3TK9b9lpB/vYqKkcwVya+onG2SgQsX2g+JVbVKxq5ixQ==
 
-svelte-meta-tags@^2.6.4:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/svelte-meta-tags/-/svelte-meta-tags-2.6.5.tgz#32ea5ef53f2dc9065ec8931efc31076b75ae9387"
-  integrity sha512-aubQoNalp4UOYY6N3I3DTaSiplxC2j5Lt7xVOCKNg+mXRPRNzZe1HxJCYyCWy1DtBbKAE+uMHjCffzA8qAjwPg==
+svelte-dnd-action@^0.9.26:
+  version "0.9.26"
+  resolved "https://registry.yarnpkg.com/svelte-dnd-action/-/svelte-dnd-action-0.9.26.tgz#b9a71096e8bea6d6de0a669d11f00b3bdda47348"
+  integrity sha512-tTRiURPX4SHM3NDcnHniMu3LeLVWhfajgODZLmukBuBWpMmMHskLlCjEZGc91bzqaHr95agWWuvcpoSMmLbbRg==
+
+svelte-meta-tags@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/svelte-meta-tags/-/svelte-meta-tags-3.0.3.tgz#15467fd5ceb7ef56ffe1a4cd532d7294e16f6fac"
+  integrity sha512-av5B6MQb1ujpM11GOYj9PDridXYJmWWJdfQvtJivFDeEc7t4Xh0hBQqcL5oEONd4Tt8UjSi0cIQG0mshTM4s+A==
   dependencies:
-    schema-dts "^1.1.0"
+    schema-dts "^1.1.2"
 
 svelte-notifications@^0.9.97:
   version "0.9.98"
   resolved "https://registry.yarnpkg.com/svelte-notifications/-/svelte-notifications-0.9.98.tgz#9c627bd363d89a347d11269bdf70f88b07302a0a"
   integrity sha512-w7/sqnQtEjM5uzjb3HfB50RE6KMuuWEQZxfBw86IykslHFJRcTuRvaUv503UMqY/LaioOu6w9mjJTO+ejiReSQ==
 
-svelte-preprocess@^4.0.0:
-  version "4.10.7"
-  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz#3626de472f51ffe20c9bc71eff5a3da66797c362"
-  integrity sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==
+svelte-preprocess@^5.0.3, svelte-preprocess@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-5.0.4.tgz#2123898e079a074f7f4ef1799e10e037f5bcc55b"
+  integrity sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==
   dependencies:
-    "@types/pug" "^2.0.4"
-    "@types/sass" "^1.16.0"
-    detect-indent "^6.0.0"
-    magic-string "^0.25.7"
-    sorcery "^0.10.0"
+    "@types/pug" "^2.0.6"
+    detect-indent "^6.1.0"
+    magic-string "^0.27.0"
+    sorcery "^0.11.0"
     strip-indent "^3.0.0"
 
 svelte-range-slider-pips@^2.0.3:
@@ -1580,35 +1697,39 @@ svelte-range-slider-pips@^2.0.3:
   resolved "https://registry.yarnpkg.com/svelte-range-slider-pips/-/svelte-range-slider-pips-2.1.1.tgz#21c188e3a3c350eeb5fa978b7b6816f7044032bc"
   integrity sha512-fLkhfnyEc4uMOCZCl8IPyC0e9lujrjqdSyrKw28Y8j99YUPZR+pHnSxde7PqhM0ST6eyO4ugh2nFnLZTIoG9aQ==
 
-svelte-routing@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/svelte-routing/-/svelte-routing-1.6.0.tgz#cdfed6b665d4a851f3d7e532e16bfbb318ce5294"
-  integrity sha512-+DbrSGttLA6lan7oWFz1MjyGabdn3tPRqn8Osyc471ut2UgCrzM5x1qViNMc2gahOP6fKbKK1aNtZMJEQP2vHQ==
-  dependencies:
-    svelte2tsx "^0.1.157"
+svelte-routing@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/svelte-routing/-/svelte-routing-2.1.0.tgz#45723f5bdca7658cd5dc6e85f812f4b0c8e52e1b"
+  integrity sha512-bPkeL2IY3tzSJLyJtW9ld8UgHWLG85Aa1rfY9CDPXilwJQ6kZBFe0mgdyiy5RT6f/L+3eBlrZa8RxFymE/1Xiw==
 
 svelte-select@^4.4.7:
   version "4.4.7"
   resolved "https://registry.yarnpkg.com/svelte-select/-/svelte-select-4.4.7.tgz#fc85414af070487d68e438f7249c653178860af3"
   integrity sha512-fIf9Z8rPI6F8naHZ9wjXT0Pv5gLyhdHAFkHFJnCfVVfELE8e82uOoF0xEVQP6Kir+b4Q5yOvNAzZ61WbSU6A0A==
 
-svelte-simple-modal@^1.1.1:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/svelte-simple-modal/-/svelte-simple-modal-1.5.2.tgz#2a41e9985bc19dcd43d31d65bd0ffced59830c80"
-  integrity sha512-kQ+9/bonxMMJe6dGTCPXBkYQQ4zF8rqqPp+PvTWOJB8QtB+Z0S/h7ZJRDZOAnkXTUClwd+Qmb2HHTIXVkjlSvA==
+svelte-simple-modal@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/svelte-simple-modal/-/svelte-simple-modal-1.6.1.tgz#8a7d77de6d8c28b9125e7df0a55e9729a0c0f58e"
+  integrity sha512-D4/Z7LQ6ThawYb7FlAeS/qGbcwVlqzRHn1zZgWPlEK0cp4l2UMcscqel58mp+gTuk4UX9gl516GYXcHFvuyslA==
 
-svelte2tsx@^0.1.157:
-  version "0.1.193"
-  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.1.193.tgz#16fe594898ef455e4f715ac317d219c9c757656b"
-  integrity sha512-vzy4YQNYDnoqp2iZPnJy7kpPAY6y121L0HKrSBjU/IWW7DQ6T7RMJed2VVHFmVYm0zAGYMDl9urPc6R4DDUyhg==
+svelte@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.2.0.tgz#0e4304c15524450b22fba02516eb72efbd8847b6"
+  integrity sha512-kVsdPjDbLrv74SmLSUzAsBGquMs4MPgWGkGLpH+PjOYnFOziAvENVzgJmyOCV2gntxE32aNm8/sqNKD6LbIpeQ==
   dependencies:
-    dedent-js "^1.0.1"
-    pascal-case "^3.1.1"
-
-svelte@^3.0.0:
-  version "3.55.1"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.55.1.tgz#6f93b153e5248039906ce5fe196efdb9e05dfce8"
-  integrity sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==
+    "@ampproject/remapping" "^2.2.1"
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    acorn "^8.9.0"
+    aria-query "^5.3.0"
+    axobject-query "^3.2.1"
+    code-red "^1.0.3"
+    css-tree "^2.3.1"
+    estree-walker "^3.0.3"
+    is-reference "^3.0.1"
+    locate-character "^3.0.0"
+    magic-string "^0.30.0"
+    periscopic "^3.1.0"
 
 terser@^5.0.0:
   version "5.16.5"
@@ -1649,15 +1770,15 @@ tslib@^1.10.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3:
+tslib@^2.0.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
-typescript@*, typescript@^4.0.0:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.0.0, typescript@^5.0.3:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"


### PR DESCRIPTION
Migrate project to Svelte 4. 

- all dependencies have been updated
- svelte-meta-tags settings have been migrated
- custom stores have been updated
- svelte-chartjs package used on the census page is not yet updated to svelte 4, but it seems to be working.