### PR TITLE
Non-song nodes shouldn't have "add to playlist label" on maps acc graph

### DIFF
--- a/src/components/Player/Charts/AccMapsChart.svelte
+++ b/src/components/Player/Charts/AccMapsChart.svelte
@@ -276,22 +276,21 @@
 										ret.push(`${song.name} (${capitalize(song?.diff?.replace('Plus', '+' ?? ''))})`);
 										ret.push(`${song.levelAuthor}`);
 									}
-									break;
-							}
-
-							if (selectedPlaylist) {
-								const item = ctx.raw;
-								if (item.playlistSong) {
-									if (item.difficulties.length == 1 && item.difficulties[0] == item.diff) {
-										ret.push(`Click to remove from the ${selectedPlaylist.playlistTitle}`);
-									} else if (item.difficulties.length == 1 || !item.difficulties.includes(item.diff)) {
-										ret.push(`Click to add this diff to the ${selectedPlaylist.playlistTitle}`);
-									} else {
-										ret.push(`Click to remove this diff from the ${selectedPlaylist.playlistTitle}`);
+									if (selectedPlaylist) {
+										const item = ctx.raw;
+										if (item.playlistSong) {
+											if (item.difficulties.length == 1 && item.difficulties[0] == item.diff) {
+												ret.push(`Click to remove from the ${selectedPlaylist.playlistTitle}`);
+											} else if (item.difficulties.length == 1 || !item.difficulties.includes(item.diff)) {
+												ret.push(`Click to add this diff to the ${selectedPlaylist.playlistTitle}`);
+											} else {
+												ret.push(`Click to remove this diff from the ${selectedPlaylist.playlistTitle}`);
+											}
+										} else {
+											ret.push(`Click to add to the ${selectedPlaylist.playlistTitle}`);
+										}
 									}
-								} else {
-									ret.push(`Click to add to the ${selectedPlaylist.playlistTitle}`);
-								}
+									break;
 							}
 
 							return ret;


### PR DESCRIPTION
![grafik](https://github.com/BeatLeader/beatleader-website/assets/924899/8b5ad1a6-a9a8-4073-8ee2-9dfa30fce422)
fixes that the nodes for the average etc have the label to add them to a playlist