### PR TITLE
delete playlist after migration

### DIFF
--- a/src/components/Playlists/Playlist.svelte
+++ b/src/components/Playlists/Playlist.svelte
@@ -83,12 +83,17 @@
 
 			for (let index = 0; index < ownersIds.length; index++) {
 				const element = ownersIds[index];
-
 				let playerService = createPlayerService();
-				let owner = await playerService.fetchPlayerOrGetFromCache(element);
-
+				let owner = playerService.fetchPlayerOrGetFromCache(element);
 				if (owner?.playerId != playerId) {
-					canModify = false;
+					if (playerService.isMainPlayer(owner.playerId)) {
+						canModify = false;
+					} else {
+						let main_id = playerService.getPlayerMain(element);
+						if (main_id == null || main_id != playerId) {
+							canModify = false;
+						}
+					}
 				}
 				if (owner) {
 					newOwners.push(owner);
@@ -135,7 +140,7 @@
 
 	$: songs = playlist.songs;
 	$: totalItems = songs.length;
-	$: updatePage(songs.length);
+	$: updatePage();
 	$: retrieveOwner(playlist, $accountStore?.player?.playerId);
 	$: updateExpanded(expanded);
 	$: description = `

--- a/src/services/beatleader/player.js
+++ b/src/services/beatleader/player.js
@@ -51,6 +51,8 @@ export default () => {
 
 	const isPlayerMain = playerId => playerId === mainPlayerId;
 
+	const getPlayerMain = playerId => mainPlayerId;
+
 	const getProfileFreshnessDate = (player, refreshInterval = null) => {
 		const lastUpdated = player && player.profileLastUpdated ? player.profileLastUpdated : null;
 		if (!lastUpdated) return addToDate(-SECOND);
@@ -120,6 +122,7 @@ export default () => {
 
 	service = {
 		isMainPlayer,
+		getPlayerMain,
 		getAll,
 		getAllActive,
 		getPlayerGain,


### PR DESCRIPTION
if you created a playlist and then migrated your account you cannot delete it since the saved owner-id is still the one from the unmigrated account. 