### PR TITLE
added hmd in leaderboard setting

### DIFF
--- a/src/components/Leaderboard/Score.svelte
+++ b/src/components/Leaderboard/Score.svelte
@@ -60,8 +60,6 @@
 		(sortBy === 'date' && $configStore?.leaderboardPreferences?.show?.date === false);
 	$: isBot = score?.player?.playerInfo?.bot;
 
-	console.log(score);
-
 	$: headset = getHeadsetForHMD(score?.score?.hmd);
 	$: controllerDescription = getControllerForEnum(score?.score?.controller).length > 0 ? ' with ' + getControllerForEnum(score?.score?.controller) : '';
 	$: platformDescription = describePlatform(score?.score?.platform);

--- a/src/components/Leaderboard/Score.svelte
+++ b/src/components/Leaderboard/Score.svelte
@@ -2,7 +2,7 @@
 	import {createEventDispatcher, getContext} from 'svelte';
 	import {navigate} from 'svelte-routing';
 	import {getTimeStringColor} from '../../utils/date';
-	import config, {configStore} from '../../stores/config';
+	import {configStore} from '../../stores/config';
 	import Button from '../Common/Button.svelte';
 	import Badge from '../Common/Badge.svelte';
 	import Value from '../Common/Value.svelte';
@@ -12,7 +12,7 @@
 	import SongScoreDetails from '../Player/SongScoreDetails.svelte';
 	import PlayerPerformance from '../Player/PlayerPerformance.svelte';
 	import Preview from '../Common/Preview.svelte';
-	import { describePlatform, getControllerForEnum, getHeadsetForHMD } from '../../utils/beatleader/format';
+	import {describePlatform, getControllerForEnum, getHeadsetForHMD} from '../../utils/beatleader/format';
 
 	export let leaderboardId = null;
 	export let score = null;
@@ -61,7 +61,8 @@
 	$: isBot = score?.player?.playerInfo?.bot;
 
 	$: headset = getHeadsetForHMD(score?.score?.hmd);
-	$: controllerDescription = getControllerForEnum(score?.score?.controller).length > 0 ? ' with ' + getControllerForEnum(score?.score?.controller) : '';
+	$: controllerDescription =
+		getControllerForEnum(score?.score?.controller).length > 0 ? ' with ' + getControllerForEnum(score?.score?.controller) : '';
 	$: platformDescription = describePlatform(score?.score?.platform);
 	$: title = headset?.name + controllerDescription + (platformDescription?.description ? '\n' + platformDescription?.description : '');
 	$: headsetStyle = `width: 1.2em; filter: ${headset?.color}`;

--- a/src/components/Leaderboard/Score.svelte
+++ b/src/components/Leaderboard/Score.svelte
@@ -2,7 +2,7 @@
 	import {createEventDispatcher, getContext} from 'svelte';
 	import {navigate} from 'svelte-routing';
 	import {getTimeStringColor} from '../../utils/date';
-	import {configStore} from '../../stores/config';
+	import config, {configStore} from '../../stores/config';
 	import Button from '../Common/Button.svelte';
 	import Badge from '../Common/Badge.svelte';
 	import Value from '../Common/Value.svelte';
@@ -12,6 +12,7 @@
 	import SongScoreDetails from '../Player/SongScoreDetails.svelte';
 	import PlayerPerformance from '../Player/PlayerPerformance.svelte';
 	import Preview from '../Common/Preview.svelte';
+	import { describePlatform, getControllerForEnum, getHeadsetForHMD } from '../../utils/beatleader/format';
 
 	export let leaderboardId = null;
 	export let score = null;
@@ -58,6 +59,14 @@
 		$configStore?.leaderboardPreferences?.show?.date === true ||
 		(sortBy === 'date' && $configStore?.leaderboardPreferences?.show?.date === false);
 	$: isBot = score?.player?.playerInfo?.bot;
+
+	console.log(score);
+
+	$: headset = getHeadsetForHMD(score?.score?.hmd);
+	$: controllerDescription = getControllerForEnum(score?.score?.controller).length > 0 ? ' with ' + getControllerForEnum(score?.score?.controller) : '';
+	$: platformDescription = describePlatform(score?.score?.platform);
+	$: title = headset?.name + controllerDescription + (platformDescription?.description ? '\n' + platformDescription?.description : '');
+	$: headsetStyle = `width: 1.2em; filter: ${headset?.color}`;
 </script>
 
 {#if score}
@@ -82,6 +91,9 @@
 				</Badge>
 			</div>
 			<div class="player">
+				{#if $configStore?.leaderboardPreferences?.show?.hmd !== false}
+					<img src={'/assets/' + headset?.icon} alt={headset?.name} {title} style={headsetStyle} />
+				{/if}
 				{#if $configStore?.leaderboardPreferences?.show?.avatar !== false}
 					<Avatar player={score.player} />
 				{/if}

--- a/src/components/Settings/LeaderboardSettings.svelte
+++ b/src/components/Settings/LeaderboardSettings.svelte
@@ -39,6 +39,7 @@
 						clans: false,
 						date: true,
 						replay: true,
+						hmd: false,
 					},
 				},
 			},
@@ -72,6 +73,7 @@
 						clans: true,
 						date: true,
 						replay: true,
+						hmd: false,
 					},
 				},
 			},
@@ -93,6 +95,7 @@
 						clans: true,
 						date: true,
 						replay: true,
+						hmd: false,
 					},
 				},
 			},
@@ -114,6 +117,7 @@
 						clans: true,
 						date: true,
 						replay: true,
+						hmd: false,
 					},
 				},
 			},
@@ -135,6 +139,7 @@
 						clans: true,
 						date: true,
 						replay: true,
+						hmd: false,
 					},
 				},
 			},
@@ -172,6 +177,7 @@
 		clans: 'Clans',
 		date: 'Date',
 		replay: 'Replay',
+		hmd: 'HMD',
 	};
 
 	const account = createAccountStore();

--- a/src/components/Settings/LeaderboardSettings.svelte
+++ b/src/components/Settings/LeaderboardSettings.svelte
@@ -177,7 +177,7 @@
 		clans: 'Clans',
 		date: 'Date',
 		replay: 'Replay',
-		hmd: 'HMD',
+		hmd: 'Headset',
 	};
 
 	const account = createAccountStore();

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -93,6 +93,7 @@ export const DEFAULT_CONFIG = {
 			clans: true,
 			date: true,
 			replay: true,
+			hmd: false,
 		},
 	},
 	rankingPreferences: {


### PR DESCRIPTION
super simple, just adds an option to show the hmd in the leaderboard scores. off by default

shows defaults rn because the api is returning defaults for hmd (0), controller (0) and platform (null) for some reason but there is no reason that it would not work with proper data.

![image](https://github.com/BeatLeader/beatleader-website/assets/66924896/0de58ef7-79f3-47b8-ad74-441bce5bc0fa)
