### PR TITLE
fix rain blocking clicks in case it somehow ends up in front of elements

### DIFF
--- a/src/components/Common/Rain.svelte
+++ b/src/components/Common/Rain.svelte
@@ -86,6 +86,7 @@
 		position: fixed;
 		left: -5em;
 		right: 0;
+		pointer-events: none;
 	}
 
 	.rain {
@@ -94,6 +95,7 @@
 		width: 100%;
 		height: 100%;
 		z-index: 2;
+		pointer-events: none;
 	}
 
 	.rain.back-row {
@@ -101,6 +103,7 @@
 		z-index: 1;
 		bottom: 60px;
 		opacity: 0.5;
+		pointer-events: none;
 	}
 
 	:global(.container.back-row-toggle .rain.back-row) {
@@ -114,6 +117,7 @@
 		height: 120px;
 		pointer-events: none;
 		animation: drop 0.5s linear infinite;
+		pointer-events: none;
 	}
 
 	:global(.baguette-icon) {
@@ -122,6 +126,7 @@
 		height: 80px;
 		pointer-events: none;
 		animation: baguette 2s linear infinite;
+		pointer-events: none;
 	}
 
 	@keyframes drop {
@@ -148,6 +153,7 @@
 		margin-left: 7px;
 		background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.25));
 		animation: stem 0.5s linear infinite;
+		pointer-events: none;
 	}
 
 	@keyframes stem {
@@ -174,6 +180,7 @@
 		transform: scale(0);
 		animation: splat 0.5s linear infinite;
 		display: none;
+		pointer-events: none;
 	}
 
 	@keyframes splat {

--- a/src/components/Common/RandomRain.svelte
+++ b/src/components/Common/RandomRain.svelte
@@ -84,6 +84,7 @@
 		position: fixed;
 		left: -5em;
 		right: 0;
+		pointer-events: none;
 	}
 
 	.rain {
@@ -92,6 +93,7 @@
 		width: 100%;
 		height: 100%;
 		z-index: 2;
+		pointer-events: none;
 	}
 
 	.rain.back-row {
@@ -99,6 +101,7 @@
 		z-index: 1;
 		bottom: 60px;
 		opacity: 0.5;
+		pointer-events: none;
 	}
 
 	:global(.container.back-row-toggle .rain.back-row) {
@@ -114,6 +117,7 @@
 		background-size: cover;
 		background-repeat: no-repeat;
 		background-image: url('https://cdn.assets.beatleader.xyz/SOUPclan.png');
+		pointer-events: none;
 	}
 
 	:global(.pixelsoup-icon) {
@@ -125,6 +129,7 @@
 		background-size: cover;
 		background-repeat: no-repeat;
 		background-image: url('/assets/soup_px.png');
+		pointer-events: none;
 	}
 
 	@keyframes baguette {
@@ -139,6 +144,7 @@
 		margin-left: 7px;
 		background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.25));
 		animation: stem 0.5s linear infinite;
+		pointer-events: none;
 	}
 
 	@keyframes stem {
@@ -165,6 +171,7 @@
 		transform: scale(0);
 		animation: splat 0.5s linear infinite;
 		display: none;
+		pointer-events: none;
 	}
 
 	@keyframes splat {


### PR DESCRIPTION
Sometimes the rain on pages stays when navigating to other pages before the page where the rain is used has fully loaded. This directly applies to the profile page rain effects but might happen elsewhere too. When swapping before loading the rain doesn't get taken away and ends up being the top element, and then it blocks clicks. so disabling pointer events for now.

Visually not really an issue and goes away on refresh but this is an easy fix.