### PR TITLE
Try to prevent regular users from logging in with beatsaver

### DIFF
--- a/src/pages/DeveloperPortal.svelte
+++ b/src/pages/DeveloperPortal.svelte
@@ -12,7 +12,8 @@
 	import Button from '../components/Common/Button.svelte';
 	import OauthApp from '../components/Developer/OauthApp.svelte';
 	import {fetchJson} from '../network/fetch';
-	import {BL_API_URL} from '../network/queues/beatleader/api-queue';
+	import {BL_API_URL, CURRENT_URL} from '../network/queues/beatleader/api-queue';
+	import beatSaverSvg from '../resources/beatsaver.svg';
 
 	export let page = 1;
 	export let location;
@@ -25,6 +26,7 @@
 	let createMode = false;
 	let createError = null;
 	let createIsSaving = false;
+	let showBeatSaverLogin = false;
 
 	let boxEl = null;
 
@@ -181,6 +183,36 @@
 						url="/signin"
 						onlyurl={true}
 						type="default" />
+				</div>
+			{/if}
+		</ContentBox>
+		<ContentBox>
+			<span
+				class="title is-5 chevron-clickable"
+				class:opened={showBeatSaverLogin}
+				on:click={() => (showBeatSaverLogin = !showBeatSaverLogin)}
+				on:keydown={() => (showBeatSaverLogin = !showBeatSaverLogin)}
+				title="Show login with BeatSaver">
+				Mapper login
+
+				<i class="fas fa-chevron-down" />
+			</span>
+
+			{#if showBeatSaverLogin}
+				<div transition:fade|global>
+					<p style="padding: 1em 0">
+						This login option is only for mappers that <b>do not own the game</b>, but need to login to the website to manage their maps.
+						<br /> If you are a player, please use the game login. <b style="color:#ff6666">THIS IS NOT FOR PLAYERS</b> and is
+						<b style="color:#ff6666">unusable</b> in game. <br />
+						<b style="color:#ff6666">Reesabers are not available for this login method.</b>
+					</p>
+
+					<form action={BL_API_URL + 'signin'} method="post">
+						<input type="hidden" name="Provider" value="BeatSaver" />
+						<input type="hidden" name="ReturnUrl" value={CURRENT_URL + '/signin/addHome'} />
+
+						<Button icon={beatSaverSvg} label="Login with BeatSaver" type="submit" />
+					</form>
 				</div>
 			{/if}
 		</ContentBox>
@@ -351,6 +383,15 @@
 
 	li {
 		line-height: 1.6;
+	}
+
+	.chevron-clickable > i {
+		transition: transform 500ms;
+		transform-origin: 0.42em 0.5em;
+	}
+
+	.chevron-clickable.opened > i {
+		transform: rotateZ(180deg);
 	}
 
 	@media screen and (min-width: 1250px) {

--- a/src/pages/SignIn.svelte
+++ b/src/pages/SignIn.svelte
@@ -77,14 +77,7 @@
 					</div>
 
 					{#if showBeatSaverLogin}
-						<form action={BL_API_URL + 'signin'} method="post">
-							<input type="hidden" name="Provider" value="BeatSaver" />
-							<input type="hidden" name="ReturnUrl" value={CURRENT_URL + '/signin/addHome'} />
-
-							<Button icon={beatSaverSvg} label="Login with BeatSaver" type="submit" />
-						</form>
-						<span class="beat-saver-description"
-							>By using BeatSaver login you are making the account not usable in-game. Make sure you understand what you are doing</span>
+						<a href="/developer">Click here if you do not own the game</a>
 					{/if}
 				</div>
 				<div class="login-option with-line-to-left">


### PR DESCRIPTION
Adding some extra hoops to jump through and warnings for beatsaver login, because almost all users do not need it, but its often used to login when people get confused when trying to get their patreon rewards.

I'm not sure if mapper login should at all be mentioned on the sign in page, but for now I left this there:
![image](https://github.com/BeatLeader/beatleader-website/assets/66924896/3ed69899-a37f-459a-b087-4dc0b42314b2)

this goes to the developer portal where I've just added a drop down for mapper login with some extensive warnings and red text, hopefully it's enough to make them realize along with being redirected to this page that they are on the wrong track.
![image](https://github.com/BeatLeader/beatleader-website/assets/66924896/0b328b77-db7e-4a79-9768-c570ac326126)
