### PR TITLE
Change "Source" link in footer to the GitHub Organization

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -374,7 +374,7 @@
 			|
 			<a href="https://beatleader.wiki/">Wiki</a>
 			|
-			<a href="https://github.com/BeatLeader/beatleader-website">Source</a>
+			<a href="https://github.com/BeatLeader">Source</a>
 			|
 			<a href="/privacy" on:click|preventDefault={() => navigate('/privacy')}>Privacy policy</a>
 			|


### PR DESCRIPTION
Every time I click on this source button in the footer, I always get blindsided by the fact that It takes me to the Website's source instead of the GitHub organization (for example, when trying to get to the BL Server repo). I somewhat expect the source link to take me to the source for everything