### PR TITLE
Improved importFonts() so that it doesn't try to load invalid Google font URLs

### DIFF
--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -61,3 +61,43 @@ export function importFonts(fontNames) {
 		document.head.appendChild(link);
 	});
 }
+
+export function importFonts(fontNames) {
+	// This is so we can avoid loading invalid google font API URLs for these generic font families:
+	const cssFamilies = {
+		"serif": null,
+		"sans-serif": null,
+		"monospace": null,
+		"cursive": null,
+		"fantasy": null, // Thar be dragons!
+		"system-ui": null,
+		"ui-serif": null,
+		"ui-sans-serif": null,
+		"ui-rounded": null,
+		"emoji": null, // 👍
+		"math": null, // It adds up
+		"fangsong": null // aka Simplified Chinese
+	};
+	fontNames.split(',').forEach(name => {
+		name = name.trim(); // Remove trailing whitespace *once*
+		// Skip generic font family names
+		if (name in cssFamilies) { return }
+		// Try loading the local version of the font (if present)
+		var font = new FontFace(name, `local("${name}")`);
+		document.fonts.add(font);
+		font.load().then(
+			() => {
+				// Font loaded successfully; nothing left to do
+			},
+			(err) => {
+				// Try loading the font via the google fonts API:
+				var link = document.createElement('link');
+				link.href = `https://fonts.googleapis.com/css2?family=${name
+					.split(' ')
+					.join('+')}:wght@100;200;300;400;500;600;700;800;900&display=swap`;
+				link.rel = 'stylesheet';
+				document.head.appendChild(link);
+				},
+		  );
+	});
+}


### PR DESCRIPTION
This gets rid of the errors (and unnecessary web traffic) when a theme tries to load a font that exists locally on the user's machine (that may not even exist on Google's font service).  It's also smart about when a font is specified as a generic family name like `sans-serif` or `monospace`.

If a user specifies a font that they don't have locally on their system *and* doesn't exist in Google's font service it'll still throw an error (which is what we want; I think).