### PR TITLE
Make tooltips prettier

### DIFF
--- a/src/components/Common/ToolTip.svelte
+++ b/src/components/Common/ToolTip.svelte
@@ -1,0 +1,64 @@
+<script>
+    export let content = "";
+</script>
+
+<div tooltip={content}>
+    <slot></slot>
+</div>
+
+<svelte:head>
+<style>
+    [tooltip] {
+    position: relative;
+    z-index: 2;
+    display: inline-block; 
+    }
+
+    [tooltip]:before,
+    [tooltip]:after {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+    transform: translate(-50%, 5px);
+    }
+
+    [tooltip]:before {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-bottom: 5px;
+    padding: 7px;
+    min-width: 150%;
+    max-width: 500%;
+    border-radius: 3px;
+    background-color: #222;
+    color: #fff;
+    content: attr(tooltip);
+    text-align: center;
+    font-size: 12px;
+    line-height: 1.2;
+    overflow: hidden;
+    }
+
+    [tooltip]:after {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    width: 0;
+    border-top: 5px solid #222;
+    border-right: 5px solid transparent;
+    border-left: 5px solid transparent;
+    border-radius: 3px;
+    content: '';
+    overflow: hidden;
+    }
+
+    [tooltip]:hover:before,
+    [tooltip]:hover:after {
+    visibility: visible;
+    opacity: 1;
+    transform: translate(-50%, 0);
+    }
+</style>
+</svelte:head>

--- a/src/components/Common/ToolTip.svelte
+++ b/src/components/Common/ToolTip.svelte
@@ -16,49 +16,49 @@
 
     [tooltip]:before,
     [tooltip]:after {
-    visibility: hidden;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s ease-out, transform 0.2s ease-out;
-    transform: translate(-50%, 5px);
+        visibility: hidden;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+        transform: translate(-50%, 5px);
     }
 
     [tooltip]:before {
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    margin-bottom: 5px;
-    padding: 7px;
-    min-width: 150%;
-    max-width: 500%;
-    border-radius: 3px;
-    background-color: #222;
-    color: #fff;
-    content: attr(tooltip);
-    text-align: center;
-    font-size: 12px;
-    line-height: 1.2;
-    overflow: hidden;
+        position: absolute;
+        bottom: 100%;
+        left: 50%;
+        margin-bottom: 5px;
+        padding: 7px;
+        min-width: 150%;
+        max-width: 400%;
+        border-radius: 3px;
+        background-color: #222;
+        color: #fff;
+        content: attr(tooltip);
+        text-align: center;
+        font-size: 12px;
+        line-height: 1.2;
+        overflow: hidden;
     }
 
     [tooltip]:after {
-    position: absolute;
-    bottom: 100%;
-    left: 50%;
-    width: 0;
-    border-top: 5px solid #222;
-    border-right: 5px solid transparent;
-    border-left: 5px solid transparent;
-    border-radius: 3px;
-    content: '';
-    overflow: hidden;
+        position: absolute;
+        bottom: 100%;
+        left: 50%;
+        width: 0;
+        border-top: 5px solid #222;
+        border-right: 5px solid transparent;
+        border-left: 5px solid transparent;
+        border-radius: 3px;
+        content: '';
+        overflow: hidden;
     }
 
     [tooltip]:hover:before,
     [tooltip]:hover:after {
-    visibility: visible;
-    opacity: 1;
-    transform: translate(-50%, 0);
+        visibility: visible;
+        opacity: 1;
+        transform: translate(-50%, 0);
     }
 </style>
 </svelte:head>

--- a/src/components/Player/Bio/BlBadges.svelte
+++ b/src/components/Player/Bio/BlBadges.svelte
@@ -1,6 +1,6 @@
 <script>
 	import {fade} from 'svelte/transition';
-
+	import ToolTip from '../../Common/ToolTip.svelte'
 	export let badges;
 </script>
 
@@ -9,10 +9,14 @@
 		{#each badges as badge (badge.src)}
 			{#if badge.link}
 				<a class="badge-link" href={badge.link}>
-					<img class="clickable" src={badge.src} alt={badge.title} title={badge.title} />
+					<ToolTip content={badge.title}>
+						<img class="clickable" src={badge.src} alt={badge.title} />
+					</ToolTip>
 				</a>
 			{:else}
-				<img src={badge.src} alt={badge.title} title={badge.title} />
+				<ToolTip content={badge.title}>
+					<img src={badge.src} alt={badge.title}/>
+				</ToolTip>
 			{/if}
 		{/each}
 	</div>


### PR DESCRIPTION
Add new tooltip design to replace the HTML title attribute. Currently added to profile badges only but could be added to other places in the future. 


![tooltip](https://github.com/user-attachments/assets/e7c69ea7-5966-4364-a689-6b5cb83a11cf)
