### PR TITLE
Leaderboard side boxes improvements & profile page achievements box improved

### DIFF
--- a/src/components/Leaderboard/AttemptsGraph.svelte
+++ b/src/components/Leaderboard/AttemptsGraph.svelte
@@ -30,7 +30,7 @@
 
 	let canvas = null;
 	let chart = null;
-	let height = '300px';
+	let height = '19em';
 	let isChartHovered = false;
 
 	function formatTime(seconds) {
@@ -176,7 +176,7 @@
 	$: fetchData(leaderboardId);
 
 	$: setupChart(canvas, failurePoints, isChartHovered);
-	$: height = isChartHovered ? '332px' : '300px';
+	$: height = isChartHovered ? '21em' : '19em';
 </script>
 
 <div class="stats">

--- a/src/components/Leaderboard/AttemptsGraph.svelte
+++ b/src/components/Leaderboard/AttemptsGraph.svelte
@@ -117,7 +117,7 @@
 				},
 				plugins: {
 					legend: {
-						display: isChartHovered,
+						display: false,
 						position: 'top',
 						labels: {
 							color: 'white',
@@ -176,9 +176,10 @@
 	$: fetchData(leaderboardId);
 
 	$: setupChart(canvas, failurePoints, isChartHovered);
+	$: height = isChartHovered ? '332px' : '300px';
 </script>
 
-<div class="stats" class:hidden={isChartHovered}>
+<div class="stats">
 	<div class="success-rate">
 		<div class="progress-bar">
 			<div class="progress" style="width: {successRate * 100}%"></div>
@@ -186,7 +187,7 @@
 		<div class="rate">{formatNumber(successRate * 100, 1)}% Success Rate</div>
 	</div>
 
-	<div class="attempts">
+	<div class="attempts" class:hidden={isChartHovered}>
 		<div class="count">{formatNumber(count, 0)}</div>
 		<div class="label">attempts</div>
 	</div>
@@ -204,7 +205,9 @@
 		<div class="spinner-container">Error: {error}</div>
 	{/if}
 </section>
-<div class="period" class:hidden={isChartHovered}>{formatNumber(todayCount, 0)} today, {formatNumber(weekCount, 0)} this week</div>
+{#if !isChartHovered}
+	<div class="period">{formatNumber(todayCount, 0)} today, {formatNumber(weekCount, 0)} this week</div>
+{/if}
 
 <style>
 	.stats {
@@ -212,6 +215,7 @@
 		margin-bottom: 2rem;
 		position: relative;
 		z-index: 1;
+		pointer-events: none;
 	}
 
 	.success-rate {
@@ -270,7 +274,7 @@
 		position: relative;
 		margin: 1rem auto 0 auto;
 		height: var(--height, 300px);
-		margin-top: calc(var(--height, 300px) / -1.9);
+		margin-top: -9.5em;
 	}
 
 	canvas {

--- a/src/components/Leaderboard/AttemptsGraph.svelte
+++ b/src/components/Leaderboard/AttemptsGraph.svelte
@@ -184,7 +184,10 @@
 		<div class="progress-bar">
 			<div class="progress" style="width: {successRate * 100}%"></div>
 		</div>
-		<div class="rate">{formatNumber(successRate * 100, 1)}% Success Rate</div>
+		<div class="rate">
+			<span class="rate-text">Success Rate:</span>
+			<span class="rate-value">{formatNumber(successRate * 100, 1)}%</span>
+		</div>
 	</div>
 
 	<div class="attempts" class:hidden={isChartHovered}>
@@ -244,8 +247,16 @@
 	}
 
 	.rate {
-		font-size: 1.2rem;
+		font-size: 1.25rem;
 		color: white;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.4em;
+	}
+
+	.rate-value {
+		font-weight: bold;
 	}
 
 	.attempts {

--- a/src/components/Leaderboard/ExmachinaCurve.svelte
+++ b/src/components/Leaderboard/ExmachinaCurve.svelte
@@ -142,8 +142,8 @@
 	$: loading = false;
 </script>
 
-<article>
-	<span>Predicted accability (avg {average.toFixed(2)}%):</span>
+<article class="graph-container">
+	<span class="graph-title">Predicted Accability (avg {average.toFixed(2)}%)</span>
 	<section class="accuracy-chart" style="--height: {height}">
 		<canvas class="chartjs" bind:this={canvas} />
 	</section>
@@ -153,33 +153,54 @@
 		</div>
 	{/if}
 
-	<span>At speed:</span>
-	<RangeSlider
-		min={0.5}
-		max={2}
-		step={0.05}
-		values={[speed]}
-		float
-		hoverable
-		pips
-		pipstep={10}
-		all="label"
-		suffix="x"
-		on:change={event => {
-			speed = event.detail.values[0];
-			start = new Date().getTime();
-			loading = true;
-			setTimeout(() => {
-				if (new Date().getTime() - start > 799) {
-					dispatch('speed-changed', speed);
-					loading = false;
-				}
-			}, 800);
-		}} />
+	<div class="speed-slider">
+		<RangeSlider
+			min={0.5}
+			max={2}
+			step={0.05}
+			values={[speed]}
+			float
+			hoverable
+			pips
+			pipstep={10}
+			all="label"
+			suffix="x"
+			on:change={event => {
+				speed = event.detail.values[0];
+				start = new Date().getTime();
+				loading = true;
+				setTimeout(() => {
+					if (new Date().getTime() - start > 799) {
+						dispatch('speed-changed', speed);
+						loading = false;
+					}
+				}, 800);
+			}} />
+	</div>
 </article>
 
 <style>
+	.graph-container {
+		display: flex;
+		flex-direction: column;
+		flex-wrap: nowrap;
+		align-items: center;
+		gap: 0.3em;
+	}
+
+	.graph-title {
+		font-size: 1.2rem;
+		color: white;
+	}
+
+	.speed-slider {
+		width: 100%;
+	}
 	.spinner-container {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
 	}
 
 	.accuracy-chart {

--- a/src/components/Leaderboard/ExmachinaCurve.svelte
+++ b/src/components/Leaderboard/ExmachinaCurve.svelte
@@ -205,6 +205,7 @@
 
 	.accuracy-chart {
 		height: 100%;
+		width: 100%;
 	}
 
 	canvas {

--- a/src/components/Leaderboard/ExmachinaCurve.svelte
+++ b/src/components/Leaderboard/ExmachinaCurve.svelte
@@ -10,6 +10,7 @@
 	export let notes;
 	export let height = '12em';
 	export let speed;
+	export let selectedModifiers;
 
 	const dispatch = createEventDispatcher();
 
@@ -52,6 +53,7 @@
 		if (!canvas || !chartData || !Object.keys(chartData).length) return;
 
 		const accColor = theme && theme.alternate ? theme.alternate : '#72a8ff';
+		const gridColor = '#2a2a2a';
 
 		var data = processChartData(chartData, 200, 0.02, 3);
 
@@ -114,6 +116,9 @@
 								autoSkipPadding: 4,
 								color: 'white',
 							},
+							grid: {
+								color: gridColor,
+							},
 						},
 						y: {
 							min: minMaxCounter.minValue,
@@ -123,6 +128,9 @@
 									return val + '%';
 								},
 								color: 'white',
+							},
+							grid: {
+								color: gridColor,
 							},
 						},
 					},
@@ -143,7 +151,15 @@
 </script>
 
 <article class="graph-container">
-	<span class="graph-title">Predicted Accability (avg {average.toFixed(2)}%)</span>
+	<div class="graph-title">
+		<span>Predicted Accability:</span>
+		<span class="predicted-accability">{average.toFixed(2)}%</span>
+		{#if selectedModifiers?.length}
+			<div class="modifiers-container" title="Speed: {speed}x">
+				<span>({selectedModifiers.map(m => m.name).join(', ')})</span>
+			</div>
+		{/if}
+	</div>
 	<section class="accuracy-chart" style="--height: {height}">
 		<canvas class="chartjs" bind:this={canvas} />
 	</section>
@@ -152,31 +168,6 @@
 			<Spinner />
 		</div>
 	{/if}
-
-	<div class="speed-slider">
-		<RangeSlider
-			min={0.5}
-			max={2}
-			step={0.05}
-			values={[speed]}
-			float
-			hoverable
-			pips
-			pipstep={10}
-			all="label"
-			suffix="x"
-			on:change={event => {
-				speed = event.detail.values[0];
-				start = new Date().getTime();
-				loading = true;
-				setTimeout(() => {
-					if (new Date().getTime() - start > 799) {
-						dispatch('speed-changed', speed);
-						loading = false;
-					}
-				}, 800);
-			}} />
-	</div>
 </article>
 
 <style>
@@ -189,8 +180,19 @@
 	}
 
 	.graph-title {
-		font-size: 1.2rem;
+		font-size: 1.25rem;
 		color: white;
+		display: inline-flex;
+		gap: 0.4em;
+	}
+
+	.modifiers-container {
+		color: white;
+		font-weight: bold;
+	}
+
+	.predicted-accability {
+		font-weight: bold;
 	}
 
 	.speed-slider {

--- a/src/components/Leaderboard/LeaderboardAsideBox.svelte
+++ b/src/components/Leaderboard/LeaderboardAsideBox.svelte
@@ -38,7 +38,11 @@
 				title="Show {title}"
 				in:receive={{key: 'button'}}
 				out:send={{key: 'button'}}>
-				<i class={faicon} />
+				<div class="left">
+					<i class={faicon} />
+					<span>{title}</span>
+				</div>
+
 				<i class="fas fa-chevron-down" />
 			</span>
 		{:else}
@@ -48,9 +52,12 @@
 				title="Hide {title}"
 				in:receive={{key: 'button'}}
 				out:send={{key: 'button'}}>
+				<div class="left">
+					<i class={faicon} />
+					<span>{title}</span>
+				</div>
+
 				<i class="fas fa-chevron-up" />
-				<i class={faicon} />
-				<span>{title}</span>
 			</span>
 		{/if}
 	</div>
@@ -74,15 +81,23 @@
 	.box-toggle-section {
 		display: grid;
 		grid-template-areas: 'button'; /* Single grid area */
-		justify-items: center;
+		justify-items: stretch;
 		min-width: max-content;
 		gap: 0.25em;
+		padding: 0 0.25em;
 	}
 
 	.reveal-button {
 		grid-area: button; /* Assign to the same grid area */
 		align-self: end;
 		cursor: pointer;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5em;
+	}
+
+	.reveal-button .left {
 		display: flex;
 		align-items: center;
 		gap: 0.5em;

--- a/src/components/Leaderboard/LeaderboardAsideBox.svelte
+++ b/src/components/Leaderboard/LeaderboardAsideBox.svelte
@@ -39,7 +39,7 @@
 				in:receive={{key: 'button'}}
 				out:send={{key: 'button'}}>
 				<i class={faicon} />
-				<i class="fas fa-chevron-right" />
+				<i class="fas fa-chevron-down" />
 			</span>
 		{:else}
 			<span
@@ -48,7 +48,7 @@
 				title="Hide {title}"
 				in:receive={{key: 'button'}}
 				out:send={{key: 'button'}}>
-				<i class="fas fa-chevron-left" />
+				<i class="fas fa-chevron-up" />
 				<i class={faicon} />
 				<span>{title}</span>
 			</span>
@@ -93,7 +93,8 @@
 		align-items: center;
 		gap: 0.25em;
 		margin-top: 0.25em;
-		width: 27em;
+		width: 100%;
+		min-width: clamp(0px, 26em, 90vw);
 	}
 
 	.darkened-background {

--- a/src/components/Leaderboard/LeaderboardAsideBox.svelte
+++ b/src/components/Leaderboard/LeaderboardAsideBox.svelte
@@ -65,6 +65,12 @@
 </ContentBox>
 
 <style>
+	:global(.leaderboard-aside-box) {
+		position: static !important;
+		border-radius: 12px !important;
+		margin-top: 0.36em !important;
+	}
+
 	.box-toggle-section {
 		display: grid;
 		grid-template-areas: 'button'; /* Single grid area */

--- a/src/components/Leaderboard/LeaderboardAsideBox.svelte
+++ b/src/components/Leaderboard/LeaderboardAsideBox.svelte
@@ -39,7 +39,9 @@
 				in:receive={{key: 'button'}}
 				out:send={{key: 'button'}}>
 				<div class="left">
-					<i class={faicon} />
+					<div class="icon-container">
+						<i class={faicon} />
+					</div>
 					<span>{title}</span>
 				</div>
 
@@ -53,7 +55,9 @@
 				in:receive={{key: 'button'}}
 				out:send={{key: 'button'}}>
 				<div class="left">
-					<i class={faicon} />
+					<div class="icon-container">
+						<i class={faicon} />
+					</div>
 					<span>{title}</span>
 				</div>
 
@@ -115,5 +119,13 @@
 	.darkened-background {
 		padding: 0.7em;
 		border-radius: 0.5em;
+	}
+
+	.icon-container {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.2em;
+		height: 1.2em;
 	}
 </style>

--- a/src/components/Leaderboard/LeaderboardAsideBox.svelte
+++ b/src/components/Leaderboard/LeaderboardAsideBox.svelte
@@ -1,5 +1,5 @@
 <script>
-	import {fade, slide} from 'svelte/transition';
+	import {slide, crossfade} from 'svelte/transition';
 	import ContentBox from '../Common/ContentBox.svelte';
 	import {configStore} from '../../stores/config';
 	import {produce} from 'immer';
@@ -8,6 +8,14 @@
 	export let title = 'box';
 	export let faicon = '';
 	export let boolname = null;
+	export let contentClass = '';
+
+	const [send, receive] = crossfade({
+		duration: 300,
+		fallback(node, params) {
+			return slide(node, {duration: 300});
+		},
+	});
 
 	function boolflip(name) {
 		if (name == null) {
@@ -21,26 +29,36 @@
 </script>
 
 <ContentBox cls="leaderboard-aside-box frosted">
-	{#if !opened}
-		<div class="box-toggle-section" transition:fade>
-			<span class="reveal-button clickable" on:click={() => boolflip(boolname)} title="Show {title}">
+	<div class="box-toggle-section">
+		{#if !opened}
+			<span
+				class="reveal-button clickable"
+				style="height: 1.5em;"
+				on:click={() => boolflip(boolname)}
+				title="Show {title}"
+				in:receive={{key: 'button'}}
+				out:send={{key: 'button'}}>
 				<i class={faicon} />
-
 				<i class="fas fa-chevron-right" />
 			</span>
-		</div>
-	{:else}
-		<div class="aside-box" transition:slide>
-			<div class="box-toggle-section">
-				<span class="reveal-button clickable" on:click={() => boolflip(boolname)} title="Hide {title}">
-					<i class="fas fa-chevron-left" />
-					<i class={faicon} />
-					<span>{title}</span>
-				</span>
-			</div>
+		{:else}
+			<span
+				class="reveal-button clickable"
+				on:click={() => boolflip(boolname)}
+				title="Hide {title}"
+				in:receive={{key: 'button'}}
+				out:send={{key: 'button'}}>
+				<i class="fas fa-chevron-left" />
+				<i class={faicon} />
+				<span>{title}</span>
+			</span>
+		{/if}
+	</div>
 
+	{#if opened}
+		<div class="aside-box" transition:slide>
 			<div class="darkened-background frosted">
-				<slot></slot>
+				<slot class={contentClass}></slot>
 			</div>
 		</div>
 	{/if}
@@ -49,17 +67,14 @@
 <style>
 	.box-toggle-section {
 		display: grid;
+		grid-template-areas: 'button'; /* Single grid area */
 		justify-items: center;
 		min-width: max-content;
-	}
-
-	.aside-box {
-		display: grid;
-		align-items: center;
 		gap: 0.25em;
 	}
 
 	.reveal-button {
+		grid-area: button; /* Assign to the same grid area */
 		align-self: end;
 		cursor: pointer;
 		display: flex;
@@ -67,13 +82,11 @@
 		gap: 0.5em;
 	}
 
-	.reveal-button > i {
-		transition: transform 500ms;
-		transform-origin: 0.42em 0.5em;
-	}
-
-	.reveal-button.opened > i {
-		transform: rotateZ(180deg);
+	.aside-box {
+		display: grid;
+		align-items: center;
+		gap: 0.25em;
+		margin-top: 0.25em;
 	}
 
 	.darkened-background {

--- a/src/components/Leaderboard/LeaderboardAsideBox.svelte
+++ b/src/components/Leaderboard/LeaderboardAsideBox.svelte
@@ -93,6 +93,7 @@
 		align-items: center;
 		gap: 0.25em;
 		margin-top: 0.25em;
+		width: 27em;
 	}
 
 	.darkened-background {

--- a/src/components/Leaderboard/LeaderboardAsideBox.svelte
+++ b/src/components/Leaderboard/LeaderboardAsideBox.svelte
@@ -1,0 +1,83 @@
+<script>
+	import {fade, slide} from 'svelte/transition';
+	import ContentBox from '../Common/ContentBox.svelte';
+	import {configStore} from '../../stores/config';
+	import {produce} from 'immer';
+
+	export let opened = false;
+	export let title = 'box';
+	export let faicon = '';
+	export let boolname = null;
+
+	function boolflip(name) {
+		if (name == null) {
+			console.log('boolname is null! cannot change aside button state!');
+			return;
+		}
+		$configStore = produce($configStore, draft => {
+			draft.preferences[name] = !draft.preferences[name];
+		});
+	}
+</script>
+
+<ContentBox cls="leaderboard-aside-box frosted">
+	{#if !opened}
+		<div class="box-toggle-section" transition:fade>
+			<span class="reveal-button clickable" on:click={() => boolflip(boolname)} title="Show {title}">
+				<i class={faicon} />
+
+				<i class="fas fa-chevron-right" />
+			</span>
+		</div>
+	{:else}
+		<div class="aside-box" transition:slide>
+			<div class="box-toggle-section">
+				<span class="reveal-button clickable" on:click={() => boolflip(boolname)} title="Hide {title}">
+					<i class="fas fa-chevron-left" />
+					<i class={faicon} />
+					<span>{title}</span>
+				</span>
+			</div>
+
+			<div class="darkened-background frosted">
+				<slot></slot>
+			</div>
+		</div>
+	{/if}
+</ContentBox>
+
+<style>
+	.box-toggle-section {
+		display: grid;
+		justify-items: center;
+		min-width: max-content;
+	}
+
+	.aside-box {
+		display: grid;
+		align-items: center;
+		gap: 0.25em;
+	}
+
+	.reveal-button {
+		align-self: end;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+	}
+
+	.reveal-button > i {
+		transition: transform 500ms;
+		transform-origin: 0.42em 0.5em;
+	}
+
+	.reveal-button.opened > i {
+		transform: rotateZ(180deg);
+	}
+
+	.darkened-background {
+		padding: 0.7em;
+		border-radius: 0.5em;
+	}
+</style>

--- a/src/components/Leaderboard/LeaderboardDevMenu.svelte
+++ b/src/components/Leaderboard/LeaderboardDevMenu.svelte
@@ -1,0 +1,149 @@
+<script>
+	import {slide, crossfade} from 'svelte/transition';
+	import Spinner from '../Common/Spinner.svelte';
+	import createBeatSaverService from '../../services/beatmaps';
+	import {getNotificationsContext} from 'svelte-notifications';
+
+	export let opened = false;
+	let title = 'Dev Menu';
+	export let faicon = 'fas fa-hashtag';
+	export let leaderboard = null;
+	export let song = null;
+
+	const [send, receive] = crossfade({
+		duration: 300,
+		fallback(node, params) {
+			return slide(node, {duration: 300});
+		},
+	});
+
+	function boolflip() {
+		opened = !opened;
+	}
+
+	let latestHash;
+	const {addNotification} = getNotificationsContext();
+
+	async function checkMapHash(hash) {
+		if (hash) {
+			let beatSaverService = createBeatSaverService();
+
+			const songInfoValue = await beatSaverService.byHash(hash, true);
+
+			latestHash = songInfoValue?.versions[0].hash.toLowerCase() == hash.toLowerCase();
+		}
+	}
+
+	function successToast(text) {
+		addNotification({
+			text: text,
+			position: 'top-right',
+			type: 'success',
+			removeAfter: 2000,
+		});
+	}
+	function copyToClipboard() {
+		var dummy = document.createElement('input');
+		var text = song.hash.toLowerCase();
+
+		document.body.appendChild(dummy);
+		dummy.value = text;
+		dummy.select();
+		document.execCommand('copy');
+		document.body.removeChild(dummy);
+
+		successToast('Hash Copied to Clipboard!');
+	}
+
+	$: song && song.hash.length == 40 && checkMapHash(song.hash);
+</script>
+
+<div class="dev-menu-container">
+	<div class="box-toggle-section">
+		{#if !opened}
+			<span
+				class="reveal-button clickable"
+				style="height: 1.5em;"
+				on:click={() => boolflip()}
+				title="Show {title}"
+				in:receive={{key: 'button'}}
+				out:send={{key: 'button'}}>
+				<i class="fas fa-chevron-down" />
+				<i class={faicon} />
+				<span>{title}</span>
+			</span>
+		{:else}
+			<span
+				class="reveal-button clickable"
+				on:click={() => boolflip()}
+				title="Hide {title}"
+				in:receive={{key: 'button'}}
+				out:send={{key: 'button'}}>
+				<i class="fas fa-chevron-up" />
+				<i class={faicon} />
+				<span>{title}</span>
+			</span>
+		{/if}
+	</div>
+
+	{#if opened && song && song.hash.length == 40}
+		<div class="aside-box" transition:slide>
+			<div class="dev-background">
+				Hash: <small on:click={() => copyToClipboard()} title="Click to copy to clipboard">{song.hash.toUpperCase()}</small>
+				{#if latestHash}
+					<i class="fa fa-check" style="color: lime;" title="Latest map version" />
+				{:else if latestHash == undefined}
+					<Spinner />
+				{:else}
+					<i class="fa fa-xmark" style="color: red;" title="Outdated map" />
+				{/if}
+				<br />
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.dev-menu-container {
+		width: 100%;
+		background-color: var(--foreground);
+		border-radius: 0.3em;
+		padding: 0.25em;
+		margin: 0.5em 0;
+	}
+
+	.box-toggle-section {
+		display: grid;
+		grid-template-areas: 'button'; /* Single grid area */
+		justify-items: center;
+		min-width: max-content;
+		gap: 0.25em;
+	}
+
+	.reveal-button {
+		grid-area: button; /* Assign to the same grid area */
+		align-self: end;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		gap: 0.5em;
+	}
+
+	.aside-box {
+		display: grid;
+		align-items: center;
+		gap: 0.25em;
+		margin-top: 0.25em;
+	}
+
+	.dev-background {
+		padding: 0.7em;
+		border-radius: 0.5em;
+		background-color: #393939;
+		height: fit-content;
+	}
+
+	.dev-background small {
+		font-size: 0.78em;
+	}
+</style>

--- a/src/components/Leaderboard/LeaderboardDevMenu.svelte
+++ b/src/components/Leaderboard/LeaderboardDevMenu.svelte
@@ -109,7 +109,7 @@
 		background-color: var(--foreground);
 		border-radius: 0.3em;
 		padding: 0.25em;
-		margin: 0.5em 0;
+		margin-top: 0.5em;
 	}
 
 	.box-toggle-section {

--- a/src/components/Leaderboard/LeaderboardStats.svelte
+++ b/src/components/Leaderboard/LeaderboardStats.svelte
@@ -89,7 +89,8 @@
 	.stats {
 		display: flex;
 		flex-wrap: wrap;
-		justify-content: space-evenly;
+		justify-content: space-between;
 		column-gap: 1em;
+		padding: 0.5em;
 	}
 </style>

--- a/src/components/Leaderboard/PPCurve.svelte
+++ b/src/components/Leaderboard/PPCurve.svelte
@@ -299,8 +299,14 @@
 		{#each modifiersArr as modifier}
 			<label
 				title={`${userDescriptionForModifier(modifier.name)}: ${formatNumber(modifier.value * 100, 0, true)}%`}
-				class:disabled={excludedModifiers.includes(modifier.name)}>
-				<input type="checkbox" bind:group={selectedModifiers} value={modifier} disabled={excludedModifiers.includes(modifier.name)} />
+				class:selected={selectedModifiers.includes(modifier)}
+				class:disabled={excludedModifiers.includes(modifier.name)}
+				on:click={() => {
+					if (excludedModifiers.includes(modifier.name)) return;
+					selectedModifiers = selectedModifiers.includes(modifier)
+						? selectedModifiers.filter(m => m !== modifier)
+						: [...selectedModifiers, modifier];
+				}}>
 				{modifier.name}
 			</label>
 		{/each}
@@ -347,18 +353,30 @@
 
 	.modifiers > * {
 		display: inline-block;
-		width: 3.4em;
+		width: 2.8em;
 	}
 
 	.modifiers label {
-		transition: color 300ms;
+		transition:
+			color 300ms,
+			background-color 300ms;
 		background-color: #4e4e4e;
 		border-radius: 0.3em;
 		padding: 0.2em 0.3em;
+		cursor: pointer;
+	}
+
+	.modifiers label.selected {
+		background-color: #6e6e6e;
 	}
 
 	.modifiers label.disabled {
 		color: var(--faded) !important;
-		background-color: var(--faded-bg);
+		background-color: #212121;
+		cursor: default;
+	}
+
+	.acc-range {
+		margin-top: 1rem;
 	}
 </style>

--- a/src/components/Leaderboard/PPCurve.svelte
+++ b/src/components/Leaderboard/PPCurve.svelte
@@ -367,7 +367,7 @@
 	}
 
 	.modifiers label.selected {
-		background-color: #6e6e6e;
+		background-color: #838383;
 	}
 
 	.modifiers label.disabled {

--- a/src/components/Leaderboard/PPCurve.svelte
+++ b/src/components/Leaderboard/PPCurve.svelte
@@ -287,6 +287,7 @@
 		accRating: modifiedAccRating,
 		techRating: modifiedTechRating,
 		stars: modifiedStars,
+		selectedModifiers,
 	});
 </script>
 

--- a/src/components/Leaderboard/PPCurve.svelte
+++ b/src/components/Leaderboard/PPCurve.svelte
@@ -338,18 +338,27 @@
 	.modifiers {
 		margin-top: 1rem;
 		text-align: center;
+		display: flex;
+		flex-wrap: wrap;
+		align-content: center;
+		justify-content: center;
+		gap: 0.75em;
 	}
 
 	.modifiers > * {
 		display: inline-block;
-		margin-right: 0.75rem;
+		width: 3.4em;
 	}
 
 	.modifiers label {
 		transition: color 300ms;
+		background-color: #4e4e4e;
+		border-radius: 0.3em;
+		padding: 0.2em 0.3em;
 	}
 
 	.modifiers label.disabled {
 		color: var(--faded) !important;
+		background-color: var(--faded-bg);
 	}
 </style>

--- a/src/components/Leaderboard/PredictedAccGraph.svelte
+++ b/src/components/Leaderboard/PredictedAccGraph.svelte
@@ -4,19 +4,24 @@
 	import ExmachinaCurve from './ExmachinaCurve.svelte';
 
 	export let leaderboard;
-
+	export let selectedModifiers;
 	const starGeneratorStore = createStarGeneratorStore();
-
-	let speed = 1.0;
 
 	$: hash = leaderboard?.song?.hash;
 	$: downloadUrl = leaderboard?.song?.downloadUrl;
 	$: diffInfo = leaderboard?.diffInfo;
+	$: speed = selectedModifiers?.find(m => m.name == 'SS')
+		? 0.8
+		: selectedModifiers?.find(m => m.name == 'SF')
+			? 1.5
+			: selectedModifiers?.find(m => m.name == 'FS')
+				? 1.2
+				: 1.0;
 	$: exmachinadata = $starGeneratorStore[hash + diffInfo?.diff + diffInfo?.type + speed];
 	$: notes = exmachinadata?.notes;
 	$: !exmachinadata && starGeneratorStore.fetchExMachina(hash, downloadUrl, diffInfo?.diff, diffInfo?.type, speed);
 </script>
 
 <article transition:fade|global>
-	<ExmachinaCurve {notes} {speed} on:speed-changed={e => (speed = e.detail)} />
+	<ExmachinaCurve {notes} {speed} {selectedModifiers} />
 </article>

--- a/src/components/Player/Achievements.svelte
+++ b/src/components/Player/Achievements.svelte
@@ -25,6 +25,7 @@
 		justify-content: center;
 		gap: 0.5em;
 		padding: 0.5em;
+		border-radius: 8px;
 	}
 	.achievements-section {
 		display: flex;

--- a/src/components/Player/Achievements.svelte
+++ b/src/components/Player/Achievements.svelte
@@ -4,16 +4,19 @@
 	export let achievements;
 </script>
 
-<div class="achievements-section">
-	{#if achievements?.length > 0}
-		<h2>Achievements</h2>
-		<div class="achievements-list">
+{#if achievements?.length > 0}
+	<div class="achievements-section">
+		<h3 class="title is-6" style="    margin: 0.2em;">
+			<i class="fa-solid fa-medal"></i>
+			<span class="maps-title">Achievements</span>
+		</h3>
+		<div class="achievements-list darkened-background">
 			{#each achievements as achievement, idx (achievement.id)}
 				<AchievementCompact {achievement} />
 			{/each}
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}
 
 <style>
 	.achievements-list {
@@ -21,11 +24,11 @@
 		flex-wrap: wrap;
 		justify-content: center;
 		gap: 0.5em;
+		padding: 0.5em;
 	}
 	.achievements-section {
 		display: flex;
 		flex-direction: column;
-		align-items: center;
-		margin-bottom: 0.5em;
+		gap: 0.4em;
 	}
 </style>

--- a/src/components/Settings/LeaderboardSettings.svelte
+++ b/src/components/Settings/LeaderboardSettings.svelte
@@ -303,6 +303,7 @@
 	$: showSubtitle = $configStore?.leaderboardPreferences?.showSubtitleInHeader ?? false;
 	$: showStats = $configStore?.leaderboardPreferences?.showStatsInHeader ?? false;
 	$: showHash = $configStore?.leaderboardPreferences?.showHashInHeader ?? false;
+	$: showDevMenu = $configStore?.leaderboardPreferences?.showDevMenu ?? false;
 	$: showGraph = $configStore?.leaderboardPreferences?.showGraphOption ?? false;
 	$: showAccGraph = $configStore?.leaderboardPreferences?.showAccGraph ?? false;
 	$: alwaysShowAuthorHint = $configStore?.leaderboardPreferences?.alwaysShowAuthorHint ?? false;
@@ -421,6 +422,14 @@
 							fontSize={12}
 							design="slider"
 							on:click={() => configStore.settempsetting('leaderboardPreferences', 'showHashInHeader', !showHash)} />
+					</div>
+					<div title="Show dev menu">
+						<Switch
+							value={showDevMenu}
+							label="Show dev menu"
+							fontSize={12}
+							design="slider"
+							on:click={() => configStore.settempsetting('leaderboardPreferences', 'showDevMenu', !showDevMenu)} />
 					</div>
 					<div title="Show scores weight graph on ranked maps in the tab options">
 						<Switch

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -1186,10 +1186,10 @@
 					boolname="leaderboardStatsShown">
 					{#if leaderboard?.stats}
 						<div class="stats-with-icons">
+							<PredictedAccGraph {leaderboard} {selectedModifiers} />
 							{#if !$configStore?.leaderboardPreferences?.showStatsInHeader}
 								<LeaderboardStats {leaderboard} />
 							{/if}
-							<PredictedAccGraph {leaderboard} {selectedModifiers} />
 							{#if $configStore?.leaderboardPreferences?.showDevMenu}
 								<LeaderboardDevMenu {leaderboard} {song} />
 							{/if}

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -1258,6 +1258,7 @@
 	}
 
 	aside {
+		width: 100%;
 		max-width: 27em;
 	}
 

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -61,7 +61,6 @@
 	import ClanRankingScore from '../components/Leaderboard/ClanRankingScore.svelte';
 	import CountryFilter from '../components/Player/ScoreFilters/CountryFilter.svelte';
 	import PredictedAccGraph from '../components/Leaderboard/PredictedAccGraph.svelte';
-	import HashDisplay from '../components/Common/HashDisplay.svelte';
 	import FeaturedPlaylist from '../components/Leaderboard/FeaturedPlaylist.svelte';
 	import ScoresAccGraph from '../components/Leaderboard/ScoresAccGraph.svelte';
 	import MapScoresChart from '../components/Leaderboard/Charts/MapScoresChart.svelte';
@@ -69,6 +68,7 @@
 	import {isPatron} from '../components/Player/Overlay/overlay';
 	import Headsets from '../components/Ranking/Headsets.svelte';
 	import LeaderboardAsideBox from '../components/Leaderboard/LeaderboardAsideBox.svelte';
+	import LeaderboardDevMenu from '../components/Leaderboard/LeaderboardDevMenu.svelte';
 
 	export let leaderboardId;
 	export let type = 'global';
@@ -1190,7 +1190,7 @@
 							{/if}
 							<PredictedAccGraph {leaderboard} />
 							{#if !$configStore?.leaderboardPreferences?.showHashInHeader}
-								<HashDisplay {song} />
+								<LeaderboardDevMenu {leaderboard} {song} />
 							{/if}
 
 							{#if iconsInInfo}
@@ -1363,8 +1363,6 @@
 		align-content: center;
 		justify-content: space-evenly;
 		flex-direction: column;
-		padding: 1em;
-		border-radius: 8px;
 	}
 
 	.scores-grid {

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -1211,25 +1211,22 @@
 
 			{#if showCurve && leaderboard?.stats?.stars}
 				<LeaderboardAsideBox opened={curveShown} title="PP Curve" faicon="fas fa-bezier-curve" boolname="curveShown">
-					<h2 class="title is-5" style="text-align: center;">
-						PP curve (<span
+					<h2 class="title is-5 pp-curve-toggles">
+						<span
 							on:click={() => curveboolflip('passPp')}
 							title="Click to show Pass PP curve"
 							class={$configStore?.ppCurve?.passPp ? 'higlighted-pp' : 'inactive-pp'}
-							><Value value={modifiedPass} prevValue={leaderboard?.stats?.passRating ?? 0} inline="true" prefix="Pass " suffix="★" /></span
-						>,
+							><Value value={modifiedPass} prevValue={leaderboard?.stats?.passRating ?? 0} inline="true" prefix="Pass " suffix="★" /></span>
 						<span
 							on:click={() => curveboolflip('accPp')}
 							title="Click to show Acc PP curve"
 							class={$configStore?.ppCurve?.accPp ? 'higlighted-pp' : 'inactive-pp'}
-							><Value value={modifiedAcc} prevValue={leaderboard?.stats?.accRating ?? 0} inline="true" prefix="Acc " suffix="★" /></span
-						>,
+							><Value value={modifiedAcc} prevValue={leaderboard?.stats?.accRating ?? 0} inline="true" prefix="Acc " suffix="★" /></span>
 						<span
 							on:click={() => curveboolflip('techPp')}
 							title="Click to show Tech PP curve"
 							class={$configStore?.ppCurve?.techPp ? 'higlighted-pp' : 'inactive-pp'}
-							><Value value={modifiedTech} prevValue={leaderboard?.stats?.techRating ?? 0} inline="true" prefix="Tech " suffix="★" /></span
-						>)
+							><Value value={modifiedTech} prevValue={leaderboard?.stats?.techRating ?? 0} inline="true" prefix="Tech " suffix="★" /></span>
 					</h2>
 					<PpCurve
 						passRating={leaderboard?.stats?.passRating}
@@ -1498,6 +1495,16 @@
 		justify-content: center;
 		align-items: center;
 		padding: 0.3em;
+	}
+
+	.pp-curve-toggles {
+		text-align: center;
+		margin: 0.5em 0;
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: 0.4em;
 	}
 
 	@media screen and (max-width: 1275px) {

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -68,6 +68,7 @@
 	import {invertColor} from '../components/Common/utils/badge';
 	import {isPatron} from '../components/Player/Overlay/overlay';
 	import Headsets from '../components/Ranking/Headsets.svelte';
+	import LeaderboardAsideBox from '../components/Leaderboard/LeaderboardAsideBox.svelte';
 
 	export let leaderboardId;
 	export let type = 'global';
@@ -1132,232 +1133,118 @@
 	{#if separatePage && type !== 'accsaber'}
 		<aside transition:fade|global>
 			{#if qualification && !isRanked}
-				<ContentBox cls="leaderboard-aside-box frosted">
-					{#if !commentaryShown}
-						<div class="score-options-section" transition:fade>
-							<span class="beat-savior-reveal clickable" on:click={() => boolflip('commentaryShown')} title="Show criteria check">
-								<i class="fas fa-comments" />
-
-								<i class="fas fa-chevron-right" />
-							</span>
-						</div>
-					{:else}
-						<div class="box-with-left-arrow" transition:slide>
-							<div class="score-options-section to-the-left">
-								<span class="beat-savior-reveal clickable" on:click={() => boolflip('commentaryShown')} title="Hide criteria details">
-									<i class="fas fa-chevron-left" />
-								</span>
-							</div>
-							<div>
-								<h1 class="status-header">Quality</h1>
-								<QualityVoting {qualification} {isNQT} currentPlayerId={$account.id} />
-								{#if isRT || isNQT || generalMapperId}
-									<Commentary {isNQT} mapperId={generalMapperId} {qualification} currentPlayerId={$account.id} />
-								{/if}
-							</div>
-						</div>
-					{/if}
-				</ContentBox>
+				<LeaderboardAsideBox opened={commentaryShown} title="Quality Votes" faicon="fas fa-comments" boolname="commentaryShown">
+					<div>
+						<QualityVoting {qualification} {isNQT} currentPlayerId={$account.id} />
+						{#if isRT || isNQT || generalMapperId}
+							<Commentary {isNQT} mapperId={generalMapperId} {qualification} currentPlayerId={$account.id} />
+						{/if}
+					</div>
+				</LeaderboardAsideBox>
 			{/if}
 			{#if (isNominated && qualification) || (leaderboard?.reweight && !leaderboard?.reweight.finished)}
-				<ContentBox cls="leaderboard-aside-box frosted"
-					>{#if !qualificationInfoShown}
-						<div class="score-options-section" transition:fade>
-							<span
-								class="beat-savior-reveal clickable"
-								on:click={() => boolflip('qualificationInfoShown')}
-								title="Show qualification details">
-								<i class="fas fa-list-ul" />
+				<LeaderboardAsideBox
+					opened={qualificationInfoShown}
+					title="Criteria Votes"
+					faicon="fas fa-list-ul"
+					boolname="qualificationInfoShown">
+					<div>
+						{#if isNominated && qualification}
+							<QualificationStatus {qualification} {isRanked} />
+							<CriteriaCommentary {isRT} {isNQT} mapperId={generalMapperId} {qualification} currentPlayerId={$account.id} />
+						{/if}
 
-								<i class="fas fa-chevron-right" />
-							</span>
-						</div>
-					{:else}
-						<div class="box-with-left-arrow" transition:slide>
-							<div class="score-options-section to-the-left">
-								<span
-									class="beat-savior-reveal clickable"
-									on:click={() => boolflip('qualificationInfoShown')}
-									title="Hide qualification details">
-									<i class="fas fa-chevron-left" />
-								</span>
-							</div>
-							<div>
-								{#if isNominated && qualification}
-									<h1 class="status-header">Criteria</h1>
-									<QualificationStatus {qualification} {isRanked} />
-									<CriteriaCommentary {isRT} {isNQT} mapperId={generalMapperId} {qualification} currentPlayerId={$account.id} />
-								{/if}
-
-								{#if leaderboard?.reweight && !leaderboard?.reweight.finished}
-									<ReweightStatus map={leaderboard} />
-								{/if}
-							</div>
-						</div>
-					{/if}
-				</ContentBox>
+						{#if leaderboard?.reweight && !leaderboard?.reweight.finished}
+							<ReweightStatus map={leaderboard} />
+						{/if}
+					</div>
+				</LeaderboardAsideBox>
 			{/if}
 			{#if featuredPlaylists && featuredPlaylists.length}
-				<ContentBox cls="leaderboard-aside-box frosted">
-					{#if !leaderboardShowPlaylists}
-						<div class="score-options-section" transition:fade>
-							<span class="beat-savior-reveal clickable" on:click={() => boolflip('leaderboardShowPlaylists')} title="Show map details">
-								<i class="fas fa-compact-disc" />
-
-								<i class="fas fa-chevron-right" />
-							</span>
-						</div>
-					{:else}
-						<div class="box-with-left-arrow" transition:slide>
-							<div class="score-options-section to-the-left">
-								<span class="beat-savior-reveal clickable" on:click={() => boolflip('leaderboardShowPlaylists')} title="Hide map details">
-									<i class="fas fa-chevron-left" />
-								</span>
+				<LeaderboardAsideBox
+					opened={leaderboardShowPlaylists}
+					title="Featured Playlists"
+					faicon="fas fa-compact-disc"
+					boolname="leaderboardShowPlaylists">
+					<div class="featured-playlists">
+						<span class="featured-playlist-headline">Featured in:</span>
+						{#each featuredPlaylists as featuredPlaylist}
+							<div class="stats-with-icons">
+								<FeaturedPlaylist playlist={featuredPlaylist} />
 							</div>
-
-							<div class="featured-playlists darkened-background frosted">
-								<span class="featured-playlist-headline">Featured in:</span>
-								{#each featuredPlaylists as featuredPlaylist}
-									<div class="stats-with-icons">
-										<FeaturedPlaylist playlist={featuredPlaylist} />
-									</div>
-								{/each}
-							</div>
-						</div>
-					{/if}
-				</ContentBox>
+						{/each}
+					</div>
+				</LeaderboardAsideBox>
 			{/if}
 
 			{#if showStats}
-				<ContentBox cls="leaderboard-aside-box frosted">
-					{#if !leaderboardStatsShown}
-						<div class="score-options-section" transition:fade>
-							<span class="beat-savior-reveal clickable" on:click={() => boolflip('leaderboardStatsShown')} title="Show map details">
-								<i class="fas fa-magnifying-glass" />
+				<LeaderboardAsideBox
+					opened={leaderboardStatsShown}
+					title="Map Details"
+					faicon="fas fa-magnifying-glass"
+					boolname="leaderboardStatsShown">
+					{#if leaderboard?.stats}
+						<div class="stats-with-icons">
+							{#if !$configStore?.leaderboardPreferences?.showStatsInHeader}
+								<LeaderboardStats {leaderboard} />
+							{/if}
+							<PredictedAccGraph {leaderboard} />
+							{#if !$configStore?.leaderboardPreferences?.showHashInHeader}
+								<HashDisplay {song} />
+							{/if}
 
-								<i class="fas fa-chevron-right" />
-							</span>
-						</div>
-					{:else}
-						<div class="box-with-left-arrow" transition:slide>
-							<div class="score-options-section to-the-left">
-								<span class="beat-savior-reveal clickable" on:click={() => boolflip('leaderboardStatsShown')} title="Hide map details">
-									<i class="fas fa-chevron-left" />
-								</span>
-							</div>
-							{#if leaderboard?.stats}
-								<div class="stats-with-icons darkened-background frosted">
-									{#if !$configStore?.leaderboardPreferences?.showStatsInHeader}
-										<LeaderboardStats {leaderboard} />
-									{/if}
-									<PredictedAccGraph {leaderboard} />
-									{#if !$configStore?.leaderboardPreferences?.showHashInHeader}
-										<HashDisplay {song} />
-									{/if}
-
-									{#if iconsInInfo}
-										<Icons {song} {diffInfo} mapCheck={true} />
-									{/if}
-								</div>
+							{#if iconsInInfo}
+								<Icons {song} {diffInfo} mapCheck={true} />
 							{/if}
 						</div>
 					{/if}
-				</ContentBox>
+				</LeaderboardAsideBox>
 			{/if}
 
 			{#if showAttempts}
-				<ContentBox cls="leaderboard-aside-box frosted">
-					{#if !attemptsShown}
-						<div class="score-options-section" transition:fade>
-							<span class="beat-savior-reveal clickable" on:click={() => boolflip('attemptsShown')} title="Show attempts">
-								<i class="fas fa-chart-simple" />
-								<i class="fas fa-chevron-right" />
-							</span>
-						</div>
-					{:else}
-						<div class="box-with-left-arrow" transition:slide>
-							<div class="score-options-section to-the-left">
-								<span class="beat-savior-reveal clickable" on:click={() => boolflip('attemptsShown')} title="Hide attempts">
-									<i class="fas fa-chevron-left" />
-								</span>
-							</div>
-							<div class="darkened-background frosted">
-								<AttemptsGraph leaderboardId={currentLeaderboardId} />
-							</div>
-						</div>
+				<LeaderboardAsideBox opened={attemptsShown} title="Attempts" faicon="fas fa-chart-simple" boolname="attemptsShown">
+					{#if leaderboard?.stats?.stars}
+						<AttemptsGraph leaderboardId={currentLeaderboardId} />
 					{/if}
-				</ContentBox>
+				</LeaderboardAsideBox>
 			{/if}
 
 			{#if showCurve && leaderboard?.stats?.stars}
-				<ContentBox cls="leaderboard-aside-box frosted">
-					{#if !curveShown}
-						<div class="score-options-section" transition:fade>
-							<span class="beat-savior-reveal clickable" on:click={() => boolflip('curveShown')} title="Show pp curve">
-								<i class="fas fa-bezier-curve" />
-								<i class="fas fa-chevron-right" />
-							</span>
-						</div>
-					{:else}
-						<div class="box-with-left-arrow" transition:slide>
-							<div class="score-options-section to-the-left">
-								<span class="beat-savior-reveal clickable" on:click={() => boolflip('curveShown')} title="Hide pp curve">
-									<i class="fas fa-chevron-left" />
-								</span>
-							</div>
-							<div class="darkened-background frosted">
-								<h2 class="title is-5" style="text-align: center;">
-									PP curve (<span
-										on:click={() => curveboolflip('passPp')}
-										title="Click to show Pass PP curve"
-										class={$configStore?.ppCurve?.passPp ? 'higlighted-pp' : 'inactive-pp'}
-										><Value
-											value={modifiedPass}
-											prevValue={leaderboard?.stats?.passRating ?? 0}
-											inline="true"
-											prefix="Pass "
-											suffix="★" /></span
-									>,
-									<span
-										on:click={() => curveboolflip('accPp')}
-										title="Click to show Acc PP curve"
-										class={$configStore?.ppCurve?.accPp ? 'higlighted-pp' : 'inactive-pp'}
-										><Value
-											value={modifiedAcc}
-											prevValue={leaderboard?.stats?.accRating ?? 0}
-											inline="true"
-											prefix="Acc "
-											suffix="★" /></span
-									>,
-									<span
-										on:click={() => curveboolflip('techPp')}
-										title="Click to show Tech PP curve"
-										class={$configStore?.ppCurve?.techPp ? 'higlighted-pp' : 'inactive-pp'}
-										><Value
-											value={modifiedTech}
-											prevValue={leaderboard?.stats?.techRating ?? 0}
-											inline="true"
-											prefix="Tech "
-											suffix="★" /></span
-									>)
-								</h2>
-								<PpCurve
-									passRating={leaderboard?.stats?.passRating}
-									accRating={leaderboard?.stats?.accRating}
-									techRating={leaderboard?.stats?.techRating}
-									{modifiers}
-									modifiersRating={leaderboard?.difficultyBl?.modifiersRating}
-									mode={leaderboard?.difficultyBl?.modeName.toLowerCase()}
-									on:modified-stars={e => {
-										modifiedPass = e?.detail?.passRating ?? 0;
-										modifiedAcc = e?.detail?.accRating ?? 0;
-										modifiedTech = e?.detail?.techRating ?? 0;
-										modifiedStars = e?.detail?.stars ?? null;
-									}} />
-							</div>
-						</div>
-					{/if}
-				</ContentBox>
+				<LeaderboardAsideBox opened={curveShown} title="PP Curve" faicon="fas fa-bezier-curve" boolname="curveShown">
+					<h2 class="title is-5" style="text-align: center;">
+						PP curve (<span
+							on:click={() => curveboolflip('passPp')}
+							title="Click to show Pass PP curve"
+							class={$configStore?.ppCurve?.passPp ? 'higlighted-pp' : 'inactive-pp'}
+							><Value value={modifiedPass} prevValue={leaderboard?.stats?.passRating ?? 0} inline="true" prefix="Pass " suffix="★" /></span
+						>,
+						<span
+							on:click={() => curveboolflip('accPp')}
+							title="Click to show Acc PP curve"
+							class={$configStore?.ppCurve?.accPp ? 'higlighted-pp' : 'inactive-pp'}
+							><Value value={modifiedAcc} prevValue={leaderboard?.stats?.accRating ?? 0} inline="true" prefix="Acc " suffix="★" /></span
+						>,
+						<span
+							on:click={() => curveboolflip('techPp')}
+							title="Click to show Tech PP curve"
+							class={$configStore?.ppCurve?.techPp ? 'higlighted-pp' : 'inactive-pp'}
+							><Value value={modifiedTech} prevValue={leaderboard?.stats?.techRating ?? 0} inline="true" prefix="Tech " suffix="★" /></span
+						>)
+					</h2>
+					<PpCurve
+						passRating={leaderboard?.stats?.passRating}
+						accRating={leaderboard?.stats?.accRating}
+						techRating={leaderboard?.stats?.techRating}
+						{modifiers}
+						modifiersRating={leaderboard?.difficultyBl?.modifiersRating}
+						mode={leaderboard?.difficultyBl?.modeName.toLowerCase()}
+						on:modified-stars={e => {
+							modifiedPass = e?.detail?.passRating ?? 0;
+							modifiedAcc = e?.detail?.accRating ?? 0;
+							modifiedTech = e?.detail?.techRating ?? 0;
+							modifiedStars = e?.detail?.stars ?? null;
+						}} />
+				</LeaderboardAsideBox>
 			{/if}
 		</aside>
 	{/if}
@@ -1462,12 +1349,6 @@
 	:global(.mode-tab-button span) {
 		font-weight: 900;
 		font-size: 1.4em;
-	}
-
-	:global(.leaderboard-aside-box) {
-		position: static !important;
-		border-radius: 12px !important;
-		margin-top: 0.36em !important;
 	}
 
 	.featured-playlists {

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -1189,7 +1189,7 @@
 								<LeaderboardStats {leaderboard} />
 							{/if}
 							<PredictedAccGraph {leaderboard} />
-							{#if !$configStore?.leaderboardPreferences?.showHashInHeader}
+							{#if $configStore?.leaderboardPreferences?.showDevMenu}
 								<LeaderboardDevMenu {leaderboard} {song} />
 							{/if}
 

--- a/src/pages/Leaderboard.svelte
+++ b/src/pages/Leaderboard.svelte
@@ -181,6 +181,7 @@
 	let modifiedAcc = null;
 	let modifiedTech = null;
 	let modifiedStars = null;
+	let selectedModifiers = [];
 
 	function initRatings(leaderboard) {
 		modifiedPass = leaderboard?.stats?.passRating;
@@ -1188,7 +1189,7 @@
 							{#if !$configStore?.leaderboardPreferences?.showStatsInHeader}
 								<LeaderboardStats {leaderboard} />
 							{/if}
-							<PredictedAccGraph {leaderboard} />
+							<PredictedAccGraph {leaderboard} {selectedModifiers} />
 							{#if $configStore?.leaderboardPreferences?.showDevMenu}
 								<LeaderboardDevMenu {leaderboard} {song} />
 							{/if}
@@ -1212,21 +1213,31 @@
 			{#if showCurve && leaderboard?.stats?.stars}
 				<LeaderboardAsideBox opened={curveShown} title="PP Curve" faicon="fas fa-bezier-curve" boolname="curveShown">
 					<h2 class="title is-5 pp-curve-toggles">
-						<span
-							on:click={() => curveboolflip('passPp')}
-							title="Click to show Pass PP curve"
-							class={$configStore?.ppCurve?.passPp ? 'higlighted-pp' : 'inactive-pp'}
-							><Value value={modifiedPass} prevValue={leaderboard?.stats?.passRating ?? 0} inline="true" prefix="Pass " suffix="★" /></span>
-						<span
-							on:click={() => curveboolflip('accPp')}
-							title="Click to show Acc PP curve"
-							class={$configStore?.ppCurve?.accPp ? 'higlighted-pp' : 'inactive-pp'}
-							><Value value={modifiedAcc} prevValue={leaderboard?.stats?.accRating ?? 0} inline="true" prefix="Acc " suffix="★" /></span>
-						<span
-							on:click={() => curveboolflip('techPp')}
-							title="Click to show Tech PP curve"
-							class={$configStore?.ppCurve?.techPp ? 'higlighted-pp' : 'inactive-pp'}
-							><Value value={modifiedTech} prevValue={leaderboard?.stats?.techRating ?? 0} inline="true" prefix="Tech " suffix="★" /></span>
+						<div class="pp-curve-toggle">
+							<span class="pp-curve-toggle-label">Pass:</span>
+							<span
+								on:click={() => curveboolflip('passPp')}
+								title="Click to show Pass PP curve"
+								class={$configStore?.ppCurve?.passPp ? 'higlighted-pp' : 'inactive-pp'}>
+								<Value value={modifiedPass} prevValue={leaderboard?.stats?.passRating ?? 0} inline="true" suffix="★" />
+							</span>
+						</div>
+						<div class="pp-curve-toggle">
+							<span class="pp-curve-toggle-label">Acc:</span>
+							<span
+								on:click={() => curveboolflip('accPp')}
+								title="Click to show Acc PP curve"
+								class={$configStore?.ppCurve?.accPp ? 'higlighted-pp' : 'inactive-pp'}>
+								<Value value={modifiedAcc} prevValue={leaderboard?.stats?.accRating ?? 0} inline="true" suffix="★" /></span>
+						</div>
+						<div class="pp-curve-toggle">
+							<span class="pp-curve-toggle-label">Tech:</span>
+							<span
+								on:click={() => curveboolflip('techPp')}
+								title="Click to show Tech PP curve"
+								class={$configStore?.ppCurve?.techPp ? 'higlighted-pp' : 'inactive-pp'}>
+								<Value value={modifiedTech} prevValue={leaderboard?.stats?.techRating ?? 0} inline="true" suffix="★" /></span>
+						</div>
 					</h2>
 					<PpCurve
 						passRating={leaderboard?.stats?.passRating}
@@ -1240,6 +1251,7 @@
 							modifiedAcc = e?.detail?.accRating ?? 0;
 							modifiedTech = e?.detail?.techRating ?? 0;
 							modifiedStars = e?.detail?.stars ?? null;
+							selectedModifiers = e?.detail?.selectedModifiers ?? [];
 						}} />
 				</LeaderboardAsideBox>
 			{/if}
@@ -1506,6 +1518,16 @@
 		gap: 0.4em;
 	}
 
+	.pp-curve-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.2em;
+	}
+
+	.pp-curve-toggle-label {
+		font-weight: normal;
+	}
+
 	@media screen and (max-width: 1275px) {
 		.align-content {
 			flex-direction: column;
@@ -1515,6 +1537,21 @@
 		aside {
 			width: 100%;
 			max-width: 65em;
+		}
+	}
+
+	@media screen and (max-width: 1275px) and (min-width: 927px) {
+		aside {
+			column-count: 2;
+			column-gap: 1em;
+			padding: 0 1em;
+		}
+
+		aside :global(.content-box) {
+			width: 100%;
+			margin: 0 0 1em 0;
+			break-inside: avoid;
+			display: inline-block;
 		}
 	}
 

--- a/src/pages/Player.svelte
+++ b/src/pages/Player.svelte
@@ -336,7 +336,7 @@
 				</ContentBox>
 			{/if}
 			{#if achievements?.length && $configStore.profileParts.achievements}
-				<ContentBox>
+				<ContentBox cls="player-cards-box frosted">
 					<Achievements {achievements} />
 				</ContentBox>
 			{/if}

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -111,6 +111,7 @@ export const DEFAULT_CONFIG = {
 
 		showStatsInHeader: false,
 		showHashInHeader: false,
+		showDevMenu: false,
 		showGraphOption: true,
 		showAccGraph: false,
 		showClanCaptureInHeader: true,

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -4,13 +4,11 @@ var lcount = 2;
 if (window.location.host.includes('localhost')) {
 	lcount = 1;
 }
-if (
-	window.location.host.includes('netlify.app') ||
-	window.location.host.includes('stage') ||
-	window.location.host.includes('test') ||
-	window.location.host.includes('preview')
-) {
+if (window.location.host.includes('netlify.app') || window.location.host.includes('stage') || window.location.host.includes('test')) {
 	lcount = 3;
+}
+if (window.location.host.includes('preview')) {
+	lcount = 4;
 }
 if (parseInt(location.host.split('.')[location.host.split('.').length - 1])) {
 	lcount = 4;

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -4,7 +4,12 @@ var lcount = 2;
 if (window.location.host.includes('localhost')) {
 	lcount = 1;
 }
-if (window.location.host.includes('netlify.app') || window.location.host.includes('stage') || window.location.host.includes('test')) {
+if (
+	window.location.host.includes('netlify.app') ||
+	window.location.host.includes('stage') ||
+	window.location.host.includes('test') ||
+	window.location.host.includes('preview')
+) {
 	lcount = 3;
 }
 if (parseInt(location.host.split('.')[location.host.split('.').length - 1])) {


### PR DESCRIPTION
Added a singular component for the aside boxes, so they are consistent. With animation (horizontal animation not possible).
Forced all boxes to be a consistent width.
Better aligned the map details.
Improved map details overall.
Added a dev menu in map details (with toggle in settings) as a replacement for the hash.
Improved attempts hover. (better alignment with non-hovered status, kept success rate visible)
Improved pp curve overall.
Made modifier buttons on pp curve nicer and more consistent with the rest of the site.
Also made the nqt and rt boxes work with the new component.

Also made the profile page box for achievements more consistent.