### PR TITLE
Add Score setting: showFollowedScoreIcons

### DIFF
--- a/src/components/Dashboard/FollowedScores.svelte
+++ b/src/components/Dashboard/FollowedScores.svelte
@@ -3,6 +3,7 @@
 	import ContentBox from '../Common/ContentBox.svelte';
 	import Scores from '../Player/Scores.svelte';
 	import {SPECIAL_PLAYER_ID} from '../../network/queues/beatleader/api-queue';
+	import {configStore} from '../../stores/config';
 
 	export let browserTitle;
 	const serviceParamsManager = createServiceParamsManager(SPECIAL_PLAYER_ID);
@@ -28,6 +29,8 @@
 		serviceParamsManager.update(newServiceParams);
 		serviceParams = serviceParamsManager.getParams();
 	}
+
+	$: showFollowedScoreIcons = $configStore?.scorePreferences?.showFollowedScoreIcons ?? false;
 </script>
 
 <ContentBox>
@@ -46,5 +49,5 @@
 		fixedBrowserTitle={browserTitle}
 		withPlayers={true}
 		unconstrainedPager={true}
-		noIcons={true} />
+		noIcons={!showFollowedScoreIcons} />
 </ContentBox>

--- a/src/components/Settings/ScoreSettings.svelte
+++ b/src/components/Settings/ScoreSettings.svelte
@@ -221,6 +221,7 @@
 	let currentTimeFormat = DEFAULT_TIME_FORMAT;
 	let currentShowHmd = true;
 	let currentShowTriangle = true;
+	let currentShowFollowedScoreIcons = false;
 	let currentPlaylistOption = DEFAULT_PLAYLIST_OPTION;
 
 	const scoreDetailsKeyDescription = {
@@ -249,6 +250,8 @@
 			currentTimeFormat = config?.scorePreferences?.dateFormat ?? DEFAULT_TIME_FORMAT;
 		if (config?.scorePreferences?.showHmd != currentShowHmd) currentShowHmd = config?.scorePreferences?.showHmd ?? true;
 		if (config?.scorePreferences?.showTriangle != currentShowTriangle) currentShowTriangle = config?.scorePreferences?.showTriangle ?? true;
+		if (config?.scorePreferences?.showFollowedScoreIcons != currentShowFollowedScoreIcons)
+			currentShowFollowedScoreIcons = config?.scorePreferences?.showFollowedScoreIcons ?? false;
 		if (config?.preferences?.playlistOption != currentPlaylistOption)
 			currentPlaylistOption = config?.preferences?.playlistOption ?? DEFAULT_PLAYLIST_OPTION;
 		if (stringify(config?.scoreBadges) !== stringify(currentScoreBadges)) {
@@ -358,6 +361,7 @@
 	$: configStore.settempsetting('scorePreferences', 'dateFormat', currentTimeFormat);
 	$: configStore.settempsetting('scorePreferences', 'showHmd', currentShowHmd);
 	$: configStore.settempsetting('scorePreferences', 'showTriangle', currentShowTriangle);
+	$: configStore.settempsetting('scorePreferences', 'showFollowedScoreIcons', currentShowFollowedScoreIcons);
 	$: configStore.settempsetting('scorePreferences', 'badgeRows', currentBadgeLayout);
 	$: configStore.settempsetting('scoreComparison', 'badgeRows', currentComparisonBadgeLayout);
 	$: configStore.settempsetting('scoreBadges', null, currentScoreBadges);
@@ -409,6 +413,17 @@
 								on:click={() => configStore.settempsetting('visibleScoreIcons', key, !visibleScoreIcons[key])} />
 						{/if}
 					{/each}
+				</div>
+			</section>
+			<section class="option full" id="followed-score-icons">
+				<label title="Show score action buttons on the dashboard Scores of Followed list">Followed scores (dashboard)</label>
+				<div class="switches start">
+					<Switch
+						value={currentShowFollowedScoreIcons}
+						label="Show buttons on followed scores"
+						fontSize={12}
+						design="slider"
+						on:click={() => (currentShowFollowedScoreIcons = !currentShowFollowedScoreIcons)} />
 				</div>
 			</section>
 

--- a/src/stores/config.js
+++ b/src/stores/config.js
@@ -101,6 +101,7 @@ export const DEFAULT_CONFIG = {
 		dateFormat: 'relative',
 		showHmd: true,
 		showTriangle: true,
+		showFollowedScoreIcons: false,
 	},
 	scoreBadges: [
 		[


### PR DESCRIPTION
Adds a new setting when the Scores preset is set to custom:

<img width="446" height="653" alt="image" src="https://github.com/user-attachments/assets/893fe13f-d401-43f1-9e07-df23ed050762" />

Fair warning: I didn't test what it actually looks like since I can't figure out how to login to my `netlify dev` environment, thus I didn't populate the dashboard with followed users. I'm kinda sure the dashboard elements will be a squished mess (basically I'm expecting the song title to wrap a lot more), but I would **really** like to have a way to watch my friend's web replays without having to open another tab and this was the simplest/fastest thing I could think to do!

But I will understand if you decline this PR.