### PR TITLE
fix relative date formatting for past dates in the same month

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -224,7 +224,7 @@ export function formatDateRelative(val, roundFunc = Math.floor, unit = 'auto', l
 							numeric: 'always',
 							style: 'long',
 						});
-						return rtfNumeric.format(monthDiff > 0 ? -1 : 1, 'month');
+						return rtfNumeric.format(diffInSecs > 0 ? -1 : 1, 'month');
 					}
 					return rtf.format(-monthDiff, 'month');
 				}


### PR DESCRIPTION
`monthDiff > 0` would evaluate to `0` if a score was submitted 30 days ago.
<img width="313" height="184" alt="image" src="https://github.com/user-attachments/assets/fe61d2ff-b9a5-4055-bbe7-fcecde0b8496" />

